### PR TITLE
Wire OverlayService to HookService for overlay visibility

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -19,7 +19,10 @@ public partial class App : Application
                 services.AddSingleton<Overlay.RadialMenuWindow>();
                 services.AddSingleton<IRadialMenu>(sp => sp.GetRequiredService<Overlay.RadialMenuWindow>());
                 services.AddSingleton<HookService>();
-                services.AddSingleton<OverlayService>();
+                services.AddSingleton<OverlayService>(sp =>
+                    new OverlayService(
+                        sp.GetRequiredService<IRadialMenu>(),
+                        sp.GetRequiredService<HookService>()));
                 services.AddSingleton<RadialMenuService>();
                 services.AddSingleton<CaptureService>();
                 services.AddSingleton<OpenAIService>();

--- a/src/SpecialGuide.Core/Services/OverlayService.cs
+++ b/src/SpecialGuide.Core/Services/OverlayService.cs
@@ -6,20 +6,27 @@ namespace SpecialGuide.Core.Services;
 public class OverlayService
 {
     private readonly IRadialMenu _menu;
+    private readonly HookService _hookService;
 
-    public OverlayService(IRadialMenu menu)
+    public OverlayService(IRadialMenu menu, HookService hookService)
     {
         _menu = menu;
+        _hookService = hookService;
     }
 
     public void ShowAtCursor(string[] suggestions)
     {
+        _hookService.SetOverlayVisible(true);
         var pos = GetCursorPosition();
         _menu.Populate(suggestions);
         _menu.Show(pos.X, pos.Y);
     }
 
-    public void Hide() => _menu.Hide();
+    public void Hide()
+    {
+        _hookService.SetOverlayVisible(false);
+        _menu.Hide();
+    }
 
     private static (double X, double Y) GetCursorPosition()
     {


### PR DESCRIPTION
## Summary
- inject HookService into OverlayService and toggle overlay visibility
- construct OverlayService with existing HookService instance in App.xaml.cs

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; environment lacks Windows Desktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689984beab608328a9dcc6629e5853cb