### PR TITLE
Refactor OpenAI service to use HttpClientFactory and add tests

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -16,12 +16,14 @@ public partial class App : Application
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
+                services.AddHttpClient();
                 services.AddSingleton<Overlay.RadialMenuWindow>();
                 services.AddSingleton<IRadialMenu>(sp => sp.GetRequiredService<Overlay.RadialMenuWindow>());
                 services.AddSingleton<HookService>();
                 services.AddSingleton<OverlayService>();
                 services.AddSingleton<RadialMenuService>();
                 services.AddSingleton<CaptureService>();
+                services.AddSingleton<LoggingService>();
                 services.AddSingleton<OpenAIService>();
                 services.AddSingleton<AudioService>();
                 services.AddSingleton<SuggestionService>();

--- a/src/SpecialGuide.Core/SpecialGuide.Core.csproj
+++ b/src/SpecialGuide.Core/SpecialGuide.Core.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
+++ b/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using SpecialGuide.Core.Services;
+
+namespace SpecialGuide.Tests;
+
+public class OpenAIServiceTests
+{
+    private OpenAIService CreateService(HttpResponseMessage response)
+    {
+        var handler = new FakeHandler(response);
+        var client = new HttpClient(handler);
+        var factory = new FakeFactory(client);
+        var logger = new LoggingService(NullLogger<LoggingService>.Instance);
+        var settings = new SettingsService();
+        settings.Settings.ApiKey = "test";
+        return new OpenAIService(settings, factory, logger);
+    }
+
+    [Fact]
+    public async Task ChatAsync_Returns_Content_On_Success()
+    {
+        var json = "{\"choices\":[{\"message\":{\"content\":\"hi\"}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+        var service = CreateService(response);
+        var result = await service.ChatAsync("prompt");
+        Assert.Equal("hi", result);
+    }
+
+    [Fact]
+    public async Task ChatAsync_Throws_On_Error()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("err") };
+        var service = CreateService(response);
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.ChatAsync("prompt"));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_Returns_Text_On_Success()
+    {
+        var json = "{\"text\":\"hello\"}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+        var service = CreateService(response);
+        var result = await service.TranscribeAsync(Array.Empty<byte>());
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_Throws_On_Error()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("err") };
+        var service = CreateService(response);
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.TranscribeAsync(Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public async Task GenerateSuggestionsAsync_Returns_Array_On_Success()
+    {
+        var json = "{\"choices\":[{\"message\":{\"content\":\"[\\\"a\\\",\\\"b\\\"]\"}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+        var service = CreateService(response);
+        var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+        Assert.Equal(new[] { "a", "b" }, result);
+    }
+
+    [Fact]
+    public async Task GenerateSuggestionsAsync_Throws_On_Error()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("err") };
+        var service = CreateService(response);
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app"));
+    }
+
+    private class FakeHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public FakeHandler(HttpResponseMessage response) => _response = response;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(_response);
+    }
+
+    private class FakeFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+        public FakeFactory(HttpClient client) => _client = client;
+        public HttpClient CreateClient(string name) => _client;
+    }
+}

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -1,5 +1,7 @@
 using SpecialGuide.Core.Services;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace SpecialGuide.Tests;
@@ -23,11 +25,16 @@ public class SuggestionServiceTests
 
     private class FakeOpenAIService : OpenAIService
     {
-        public FakeOpenAIService() : base(new SettingsService()) { }
+        public FakeOpenAIService() : base(new SettingsService(), new DummyFactory(), new LoggingService(NullLogger<LoggingService>.Instance)) { }
         public override async Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
         {
             await Task.CompletedTask;
             return new[] { new string('a', 100) };
         }
+    }
+
+    private class DummyFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new HttpClient();
     }
 }


### PR DESCRIPTION
## Summary
- use IHttpClientFactory and LoggingService in OpenAIService
- add typed response records and error handling
- register LoggingService/HttpClient and add unit tests for OpenAIService

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: The name 'Clipboard' does not exist in the current context)*

------
https://chatgpt.com/codex/tasks/task_e_689984b25d00832884a1b9fbb006bfe7