### PR TITLE
Add ActiveWindowService to provide active window titles

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -27,6 +27,8 @@ public partial class App : Application
                 services.AddSingleton<SuggestionService>();
                 services.AddSingleton<ClipboardService>();
                 services.AddSingleton<SettingsService>();
+                services.AddSingleton<IWin32Api, Win32Api>();
+                services.AddSingleton<ActiveWindowService>();
                 services.AddSingleton<MainWindow>();
             })
             .Build();

--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -8,20 +8,23 @@ public partial class MainWindow : Window
     private readonly HookService _hookService;
     private readonly OverlayService _overlayService;
     private readonly SuggestionService _suggestionService;
+    private readonly ActiveWindowService _activeWindowService;
 
-    public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService)
+    public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService, ActiveWindowService activeWindowService)
     {
         InitializeComponent();
         _hookService = hookService;
         _overlayService = overlayService;
         _suggestionService = suggestionService;
+        _activeWindowService = activeWindowService;
         _hookService.MiddleClick += OnMiddleClick;
         _hookService.Start();
     }
 
     private async void OnMiddleClick(object? sender, EventArgs e)
     {
-        var suggestions = await _suggestionService.GetSuggestionsAsync("app");
+        var appName = _activeWindowService.GetActiveWindowTitle();
+        var suggestions = await _suggestionService.GetSuggestionsAsync(appName);
         _overlayService.ShowAtCursor(suggestions);
     }
 }

--- a/src/SpecialGuide.Core/Services/ActiveWindowService.cs
+++ b/src/SpecialGuide.Core/Services/ActiveWindowService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SpecialGuide.Core.Services;
+
+public interface IWin32Api
+{
+    IntPtr GetForegroundWindow();
+    int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+}
+
+public class Win32Api : IWin32Api
+{
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+    IntPtr IWin32Api.GetForegroundWindow() => GetForegroundWindow();
+
+    int IWin32Api.GetWindowText(IntPtr hWnd, StringBuilder text, int count) => GetWindowText(hWnd, text, count);
+}
+
+public class ActiveWindowService
+{
+    private readonly IWin32Api _api;
+
+    public ActiveWindowService(IWin32Api api)
+    {
+        _api = api;
+    }
+
+    public string GetActiveWindowTitle()
+    {
+        var handle = _api.GetForegroundWindow();
+        if (handle == IntPtr.Zero)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(256);
+        _api.GetWindowText(handle, sb, sb.Capacity);
+        return sb.ToString();
+    }
+}

--- a/tests/SpecialGuide.Tests/ActiveWindowServiceTests.cs
+++ b/tests/SpecialGuide.Tests/ActiveWindowServiceTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using SpecialGuide.Core.Services;
+using Xunit;
+
+namespace SpecialGuide.Tests;
+
+public class ActiveWindowServiceTests
+{
+    [Fact]
+    public void Returns_Empty_When_No_Window()
+    {
+        var api = new FakeWin32Api(IntPtr.Zero, string.Empty);
+        var service = new ActiveWindowService(api);
+        var result = service.GetActiveWindowTitle();
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Returns_Title_From_Api()
+    {
+        var api = new FakeWin32Api(new IntPtr(1), "Notepad");
+        var service = new ActiveWindowService(api);
+        var result = service.GetActiveWindowTitle();
+        Assert.Equal("Notepad", result);
+    }
+
+    private class FakeWin32Api : IWin32Api
+    {
+        private readonly IntPtr _handle;
+        private readonly string _title;
+
+        public FakeWin32Api(IntPtr handle, string title)
+        {
+            _handle = handle;
+            _title = title;
+        }
+
+        public IntPtr GetForegroundWindow() => _handle;
+
+        public int GetWindowText(IntPtr hWnd, StringBuilder text, int count)
+        {
+            text.Clear();
+            text.Append(_title);
+            return _title.Length;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ActiveWindowService` using Win32 APIs via wrapper interface
- inject ActiveWindowService into MainWindow and DI setup
- test ActiveWindowService with mocked Win32 API

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" and FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms' was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_689984ac7a988328ab7aa63f74485ab5