### PR TITLE
Handle clipboard and sendinput failures with logging

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -25,6 +25,7 @@ public partial class App : Application
                 services.AddSingleton<OpenAIService>();
                 services.AddSingleton<AudioService>();
                 services.AddSingleton<SuggestionService>();
+                services.AddSingleton<LoggingService>();
                 services.AddSingleton<ClipboardService>();
                 services.AddSingleton<SettingsService>();
                 services.AddSingleton<MainWindow>();

--- a/src/SpecialGuide.Core/Services/ClipboardService.cs
+++ b/src/SpecialGuide.Core/Services/ClipboardService.cs
@@ -5,18 +5,38 @@ namespace SpecialGuide.Core.Services;
 
 public class ClipboardService
 {
-    public bool AutoPaste { get; set; }
+    private readonly LoggingService _loggingService;
 
-    public void SetText(string text)
+    public ClipboardService(LoggingService loggingService)
     {
-        Clipboard.SetText(text);
-        if (AutoPaste)
-        {
-            SendCtrlV();
-        }
+        _loggingService = loggingService;
     }
 
-    private static void SendCtrlV()
+    public bool AutoPaste { get; set; }
+
+    public bool SetText(string text)
+    {
+        try
+        {
+            SetClipboardText(text);
+        }
+        catch (Exception ex)
+        {
+            _loggingService.LogError(ex, "Failed to set clipboard text.");
+            return false;
+        }
+
+        if (AutoPaste && !SendCtrlV())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected virtual void SetClipboardText(string text) => Clipboard.SetText(text);
+
+    private bool SendCtrlV()
     {
         var inputs = new INPUT[]
         {
@@ -25,27 +45,39 @@ public class ClipboardService
             new INPUT { type = 1, U = new InputUnion { ki = new KEYBDINPUT { wVk = 0x56, dwFlags = 2 } } }, // V up
             new INPUT { type = 1, U = new InputUnion { ki = new KEYBDINPUT { wVk = 0x11, dwFlags = 2 } } } // Ctrl up
         };
-        SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+
+        try
+        {
+            SendInputWrapper((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _loggingService.LogError(ex, "Failed to send Ctrl+V.");
+            return false;
+        }
     }
+
+    protected virtual uint SendInputWrapper(uint nInputs, INPUT[] pInputs, int cbSize) => SendInput(nInputs, pInputs, cbSize);
 
     [DllImport("user32.dll")]
     private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct INPUT
+    protected struct INPUT
     {
         public uint type;
         public InputUnion U;
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    private struct InputUnion
+    protected struct InputUnion
     {
         [FieldOffset(0)] public KEYBDINPUT ki;
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct KEYBDINPUT
+    protected struct KEYBDINPUT
     {
         public ushort wVk;
         public ushort wScan;

--- a/src/SpecialGuide.Core/Services/LoggingService.cs
+++ b/src/SpecialGuide.Core/Services/LoggingService.cs
@@ -11,5 +11,5 @@ public class LoggingService
         _logger = logger;
     }
 
-    public void LogError(Exception ex, string message) => _logger.LogError(ex, message);
+    public virtual void LogError(Exception ex, string message) => _logger.LogError(ex, message);
 }

--- a/src/SpecialGuide.Core/SpecialGuide.Core.csproj
+++ b/src/SpecialGuide.Core/SpecialGuide.Core.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/tests/SpecialGuide.Tests/ClipboardServiceTests.cs
+++ b/tests/SpecialGuide.Tests/ClipboardServiceTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using SpecialGuide.Core.Services;
+using Xunit;
+
+namespace SpecialGuide.Tests;
+
+public class ClipboardServiceTests
+{
+    private class TestLoggingService : LoggingService
+    {
+        public List<string> Messages { get; } = new();
+
+        public TestLoggingService() : base(new LoggerFactory().CreateLogger<LoggingService>()) { }
+
+        public override void LogError(Exception ex, string message) => Messages.Add(message);
+    }
+
+    private class TestClipboardService : ClipboardService
+    {
+        public bool ThrowOnSet { get; set; }
+        public bool ThrowOnSend { get; set; }
+
+        public TestClipboardService(LoggingService logger) : base(logger) { }
+
+        protected override void SetClipboardText(string text)
+        {
+            if (ThrowOnSet)
+            {
+                throw new Exception("SetClipboardText failure");
+            }
+        }
+
+        protected override uint SendInputWrapper(uint nInputs, INPUT[] pInputs, int cbSize)
+        {
+            if (ThrowOnSend)
+            {
+                throw new Exception("SendInput failure");
+            }
+            return 0;
+        }
+    }
+
+    [Fact]
+    public void SetText_ClipboardFails_ReturnsFalseAndLogs()
+    {
+        var logger = new TestLoggingService();
+        var service = new TestClipboardService(logger) { ThrowOnSet = true };
+
+        var result = service.SetText("test");
+
+        Assert.False(result);
+        Assert.Contains("Failed to set clipboard text.", logger.Messages);
+    }
+
+    [Fact]
+    public void SetText_SendInputFails_ReturnsFalseAndLogs()
+    {
+        var logger = new TestLoggingService();
+        var service = new TestClipboardService(logger) { AutoPaste = true, ThrowOnSend = true };
+
+        var result = service.SetText("test");
+
+        Assert.False(result);
+        Assert.Contains("Failed to send Ctrl+V.", logger.Messages);
+    }
+}
+

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />


### PR DESCRIPTION
## Summary
- return a success flag from ClipboardService.SetText and log exceptions when clipboard or simulated input fails
- expose LoggingService for dependency injection and register it in the app
- add unit tests covering Clipboard.SetText and SendInput error paths

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_689984ab66808328a1ddbb0cf6446419