### PR TITLE
Wrap middle-click handler in async logging wrapper

### DIFF
--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Microsoft.Extensions.Logging;
 using SpecialGuide.Core.Services;
 
 namespace SpecialGuide.App;
@@ -8,18 +9,29 @@ public partial class MainWindow : Window
     private readonly HookService _hookService;
     private readonly OverlayService _overlayService;
     private readonly SuggestionService _suggestionService;
-
-    public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService)
+    private readonly ILogger<MainWindow> _logger;
+    public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService, ILogger<MainWindow> logger)
     {
         InitializeComponent();
         _hookService = hookService;
         _overlayService = overlayService;
         _suggestionService = suggestionService;
-        _hookService.MiddleClick += OnMiddleClick;
+        _logger = logger;
+        _hookService.MiddleClick += async (sender, e) =>
+        {
+            try
+            {
+                await OnMiddleClick(sender, e);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error handling middle click");
+            }
+        };
         _hookService.Start();
     }
 
-    private async void OnMiddleClick(object? sender, EventArgs e)
+    private async Task OnMiddleClick(object? sender, EventArgs e)
     {
         var suggestions = await _suggestionService.GetSuggestionsAsync("app");
         _overlayService.ShowAtCursor(suggestions);


### PR DESCRIPTION
## Summary
- wrap MiddleClick handler in try/catch logging and await actual handler
- convert `OnMiddleClick` to return `Task`

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: The name 'SystemParameters' does not exist in the current context)*

------
https://chatgpt.com/codex/tasks/task_e_689984a7e5588328955ebf613ab4a6b0