### PR TITLE
Use configuration-based settings and sync AutoPaste

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SpecialGuide.Core.Models;
@@ -14,8 +15,9 @@ public partial class App : Application
     {
         base.OnStartup(e);
         _host = Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
+            .ConfigureServices((context, services) =>
             {
+                services.Configure<Settings>(context.Configuration.GetSection("Settings"));
                 services.AddSingleton<Overlay.RadialMenuWindow>();
                 services.AddSingleton<IRadialMenu>(sp => sp.GetRequiredService<Overlay.RadialMenuWindow>());
                 services.AddSingleton<HookService>();
@@ -25,8 +27,8 @@ public partial class App : Application
                 services.AddSingleton<OpenAIService>();
                 services.AddSingleton<AudioService>();
                 services.AddSingleton<SuggestionService>();
-                services.AddSingleton<ClipboardService>();
                 services.AddSingleton<SettingsService>();
+                services.AddSingleton<ClipboardService>();
                 services.AddSingleton<MainWindow>();
             })
             .Build();

--- a/src/SpecialGuide.Core/Services/ClipboardService.cs
+++ b/src/SpecialGuide.Core/Services/ClipboardService.cs
@@ -5,7 +5,15 @@ namespace SpecialGuide.Core.Services;
 
 public class ClipboardService
 {
-    public bool AutoPaste { get; set; }
+    public bool AutoPaste { get; private set; }
+
+    public ClipboardService(SettingsService settings)
+    {
+        UpdateAutoPaste(settings.Settings.AutoPaste);
+        settings.SettingsChanged += s => UpdateAutoPaste(s.AutoPaste);
+    }
+
+    public void UpdateAutoPaste(bool autoPaste) => AutoPaste = autoPaste;
 
     public void SetText(string text)
     {

--- a/src/SpecialGuide.Core/Services/SettingsService.cs
+++ b/src/SpecialGuide.Core/Services/SettingsService.cs
@@ -1,34 +1,20 @@
 using System;
-using System.IO;
-using System.Text.Json;
+using Microsoft.Extensions.Options;
 using SpecialGuide.Core.Models;
 
 namespace SpecialGuide.Core.Services;
 
 public class SettingsService
 {
-    private readonly string _path;
-    public Settings Settings { get; private set; }
+    private readonly IOptionsMonitor<Settings> _settings;
+    public Settings Settings => _settings.CurrentValue;
     public string ApiKey => Settings.ApiKey;
 
-    public SettingsService()
-    {
-        var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SpecialGuide");
-        _path = Path.Combine(folder, "settings.json");
-        if (File.Exists(_path))
-        {
-            Settings = JsonSerializer.Deserialize<Settings>(File.ReadAllText(_path)) ?? new Settings();
-        }
-        else
-        {
-            Settings = new Settings();
-        }
-    }
+    public event Action<Settings>? SettingsChanged;
 
-    public void Save()
+    public SettingsService(IOptionsMonitor<Settings> settings)
     {
-        var folder = Path.GetDirectoryName(_path)!;
-        Directory.CreateDirectory(folder);
-        File.WriteAllText(_path, JsonSerializer.Serialize(Settings, new JsonSerializerOptions { WriteIndented = true }));
+        _settings = settings;
+        _settings.OnChange(s => SettingsChanged?.Invoke(s));
     }
 }

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Options;
+using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 using System.Threading.Tasks;
 using Xunit;
@@ -23,11 +25,24 @@ public class SuggestionServiceTests
 
     private class FakeOpenAIService : OpenAIService
     {
-        public FakeOpenAIService() : base(new SettingsService()) { }
+        public FakeOpenAIService() : base(new SettingsService(new FakeOptionsMonitor<Settings>(new Settings()))) { }
         public override async Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
         {
             await Task.CompletedTask;
             return new[] { new string('a', 100) };
+        }
+    }
+
+    private class FakeOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public FakeOptionsMonitor(T currentValue) => CurrentValue = currentValue;
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable OnChange(Action<T, string> listener) => new DummyDisposable();
+
+        private sealed class DummyDisposable : IDisposable
+        {
+            public void Dispose() { }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wire settings through `IOptionsMonitor` and raise change events
- Load AutoPaste configuration in `ClipboardService` and update on settings changes
- Register configuration binding for `Settings`

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms' was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_689984a1e42083289d2b7bd1ba36d16b