### PR TITLE
Inject HttpClient for OpenAIService and improve error handling

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -23,7 +23,8 @@ public partial class App : Application
                 services.AddSingleton<HookService>();
                 services.AddSingleton<OverlayService>();
                 services.AddSingleton<CaptureService>();
-                services.AddSingleton<OpenAIService>();
+                services.AddSingleton<LoggingService>();
+                services.AddHttpClient<OpenAIService>();
                 services.AddSingleton<AudioService>();
                 services.AddSingleton<SuggestionService>();
                 services.AddSingleton<SettingsService>();

--- a/src/SpecialGuide.App/SpecialGuide.App.csproj
+++ b/src/SpecialGuide.App/SpecialGuide.App.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Gma.System.MouseKeyHook" Version="7.6.1" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- inject HttpClient and LoggingService into OpenAIService
- centralize chat request creation and add SendAsync helper with status checks
- register typed HttpClient and logging services in app startup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b72ef38688328b9f38b4ac4aab063