### PR TITLE
Rename CaptureScreen to synchronous method

### DIFF
--- a/src/SpecialGuide.Core/Services/CaptureService.cs
+++ b/src/SpecialGuide.Core/Services/CaptureService.cs
@@ -7,7 +7,7 @@ namespace SpecialGuide.Core.Services;
 
 public class CaptureService
 {
-    public virtual Task<byte[]> CaptureScreenAsync()
+    public virtual byte[] CaptureScreen()
     {
         var width = (int)SystemParameters.PrimaryScreenWidth;
         var height = (int)SystemParameters.PrimaryScreenHeight;
@@ -18,6 +18,6 @@ public class CaptureService
         }
         using var ms = new MemoryStream();
         bmp.Save(ms, ImageFormat.Png);
-        return Task.FromResult(ms.ToArray());
+        return ms.ToArray();
     }
 }

--- a/src/SpecialGuide.Core/Services/SuggestionService.cs
+++ b/src/SpecialGuide.Core/Services/SuggestionService.cs
@@ -15,7 +15,7 @@ public class SuggestionService
 
     public async Task<string[]> GetSuggestionsAsync(string appName)
     {
-        var image = await _capture.CaptureScreenAsync();
+        var image = _capture.CaptureScreen();
         var suggestions = await _openAI.GenerateSuggestionsAsync(image, appName);
         return suggestions.Select(s => s.Length > 80 ? s[..80] : s).ToArray();
     }

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -20,7 +20,7 @@ public class SuggestionServiceTests
 
     private class FakeCaptureService : CaptureService
     {
-        public override Task<byte[]> CaptureScreenAsync() => Task.FromResult(Array.Empty<byte>());
+        public override byte[] CaptureScreen() => Array.Empty<byte>();
     }
 
     private class FakeOpenAIService : OpenAIService


### PR DESCRIPTION
## Summary
- Make screen capture synchronous by renaming `CaptureScreenAsync` to `CaptureScreen`
- Update suggestion service and tests to use new `CaptureScreen`

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Source file 'RadialMenuServiceTests.cs' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689b72efcffc8328b779c77aca2dd970