### PR TITLE
Remove suggestion service dependency from radial menu

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -25,7 +25,6 @@ public partial class App : Application
                 services.AddSingleton<CaptureService>();
                 services.AddSingleton<OpenAIService>();
                 services.AddSingleton<AudioService>();
-                services.AddSingleton<SuggestionService>();
                 services.AddSingleton<SettingsService>();
                 services.AddSingleton<ClipboardService>();
                 services.AddSingleton<MainWindow>();

--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
@@ -7,14 +7,12 @@ namespace SpecialGuide.App.Overlay;
 
 public partial class RadialMenuWindow : Window, IRadialMenu
 {
-    private readonly SuggestionService _suggestionService;
     private readonly ClipboardService _clipboardService;
     private readonly HookService _hookService;
 
-    public RadialMenuWindow(SuggestionService suggestionService, ClipboardService clipboardService, HookService hookService)
+    public RadialMenuWindow(ClipboardService clipboardService, HookService hookService)
     {
         InitializeComponent();
-        _suggestionService = suggestionService;
         _clipboardService = clipboardService;
         _hookService = hookService;
     }


### PR DESCRIPTION
## Summary
- drop SuggestionService from radial menu window and its constructor
- update service registration to exclude SuggestionService

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found; missing test files and Options types)*

------
https://chatgpt.com/codex/tasks/task_e_689b72f0856c8328835a47e195449218