### PR TITLE
Add window service to fetch active process name

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -28,6 +28,7 @@ public partial class App : Application
                 services.AddSingleton<SuggestionService>();
                 services.AddSingleton<SettingsService>();
                 services.AddSingleton<ClipboardService>();
+                services.AddSingleton<WindowService>();
                 services.AddSingleton<MainWindow>();
             })
             .Build();

--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -9,13 +9,15 @@ public partial class MainWindow : Window
     private readonly HookService _hookService;
     private readonly OverlayService _overlayService;
     private readonly SuggestionService _suggestionService;
+    private readonly WindowService _windowService;
     private readonly ILogger<MainWindow> _logger;
-    public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService, ILogger<MainWindow> logger)
+    public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService, WindowService windowService, ILogger<MainWindow> logger)
     {
         InitializeComponent();
         _hookService = hookService;
         _overlayService = overlayService;
         _suggestionService = suggestionService;
+        _windowService = windowService;
         _logger = logger;
         _hookService.MiddleClick += async (sender, e) =>
         {
@@ -33,7 +35,8 @@ public partial class MainWindow : Window
 
     private async Task OnMiddleClick(object? sender, EventArgs e)
     {
-        var suggestions = await _suggestionService.GetSuggestionsAsync("app");
+        var app = _windowService.GetActiveProcessName();
+        var suggestions = await _suggestionService.GetSuggestionsAsync(app);
         _overlayService.ShowAtCursor(suggestions);
     }
 }

--- a/src/SpecialGuide.Core/Services/WindowService.cs
+++ b/src/SpecialGuide.Core/Services/WindowService.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SpecialGuide.Core.Services;
+
+public class WindowService
+{
+    public virtual string GetActiveProcessName()
+    {
+        var hWnd = GetForegroundWindow();
+        if (hWnd == IntPtr.Zero)
+        {
+            return string.Empty;
+        }
+
+        _ = GetWindowThreadProcessId(hWnd, out uint processId);
+        try
+        {
+            using var process = Process.GetProcessById((int)processId);
+            return process.ProcessName;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    public virtual string GetActiveWindowTitle()
+    {
+        var hWnd = GetForegroundWindow();
+        if (hWnd == IntPtr.Zero)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(256);
+        _ = GetWindowText(hWnd, sb, sb.Capacity);
+        return sb.ToString();
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+}
+


### PR DESCRIPTION
## Summary
- implement WindowService using Win32 APIs to get foreground process/title
- inject WindowService into MainWindow and pass real app name to suggestions
- register WindowService with application services

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Source file '../../src/SpecialGuide.Core/Services/RadialMenuService.cs' could not be found)*
- `dotnet build src/SpecialGuide.Core/SpecialGuide.Core.csproj` *(fails: FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms' was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_689b72f0ec7c8328906d5f957d4a97af