### PR TITLE
Expose AudioService internals for testing

### DIFF
--- a/src/SpecialGuide.Core/Services/AudioService.cs
+++ b/src/SpecialGuide.Core/Services/AudioService.cs
@@ -5,23 +5,23 @@ namespace SpecialGuide.Core.Services;
 public class AudioService : IDisposable
 {
     private WaveInEvent? _waveIn;
-    private MemoryStream? _stream;
-    private WaveFileWriter? _writer;
+    protected internal virtual MemoryStream? Stream { get; set; }
+    protected internal virtual WaveFileWriter? Writer { get; set; }
 
     public void Start()
     {
         _waveIn = new WaveInEvent();
-        _stream = new MemoryStream();
-        _writer = new WaveFileWriter(_stream, _waveIn.WaveFormat);
-        _waveIn.DataAvailable += (s, a) => _writer.Write(a.Buffer, 0, a.BytesRecorded);
+        Stream = new MemoryStream();
+        Writer = new WaveFileWriter(Stream, _waveIn.WaveFormat);
+        _waveIn.DataAvailable += (s, a) => Writer.Write(a.Buffer, 0, a.BytesRecorded);
         _waveIn.StartRecording();
     }
 
     public byte[] Stop()
     {
         _waveIn?.StopRecording();
-        _writer?.Flush();
-        var data = _stream?.ToArray() ?? Array.Empty<byte>();
+        Writer?.Flush();
+        var data = Stream?.ToArray() ?? Array.Empty<byte>();
         Dispose();
         return data;
     }
@@ -30,9 +30,9 @@ public class AudioService : IDisposable
     {
         _waveIn?.Dispose();
         _waveIn = null;
-        _writer?.Dispose();
-        _writer = null;
-        _stream?.Dispose();
-        _stream = null;
+        Writer?.Dispose();
+        Writer = null;
+        Stream?.Dispose();
+        Stream = null;
     }
 }

--- a/src/SpecialGuide.Core/SpecialGuide.Core.csproj
+++ b/src/SpecialGuide.Core/SpecialGuide.Core.csproj
@@ -10,4 +10,7 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="SpecialGuide.Tests" />
+  </ItemGroup>
 </Project>

--- a/tests/SpecialGuide.Tests/AudioServiceTests.cs
+++ b/tests/SpecialGuide.Tests/AudioServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using NAudio.Wave;
 using SpecialGuide.Core.Services;
 using Xunit;
@@ -16,14 +15,13 @@ public class AudioServiceTests
         var stream = new MemoryStream();
         var writer = new WaveFileWriter(stream, new WaveFormat(8000, 16, 1));
 
-        var type = typeof(AudioService);
-        type.GetField("_stream", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(service, stream);
-        type.GetField("_writer", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(service, writer);
+        service.Stream = stream;
+        service.Writer = writer;
 
         var data = service.Stop();
         Assert.NotNull(data);
 
-        Assert.Null(type.GetField("_stream", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(service));
-        Assert.Null(type.GetField("_writer", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(service));
+        Assert.Null(service.Stream);
+        Assert.Null(service.Writer);
     }
 }


### PR DESCRIPTION
## Summary
- replace private audio buffers with protected internal virtual properties
- grant test assembly internal access via `InternalsVisibleTo`
- update tests to use new hooks instead of reflection

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Source file 'RadialMenuServiceTests.cs' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689b72f4b0b883289a186a77e23fc4e0