### PR TITLE
refactor: use ILogger for OpenAI logging

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -27,7 +27,6 @@ public partial class App : Application
                 services.AddSingleton<HookService>();
                 services.AddSingleton<OverlayService>();
                 services.AddSingleton<CaptureService>();
-                services.AddSingleton<LoggingService>();
                 services.AddHttpClient<OpenAIService>();
                 services.AddSingleton<AudioService>();
                 services.AddSingleton<SettingsService>();

--- a/src/SpecialGuide.Core/Services/OpenAIService.cs
+++ b/src/SpecialGuide.Core/Services/OpenAIService.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace SpecialGuide.Core.Services;
 
@@ -9,9 +10,9 @@ public class OpenAIService
 {
     private readonly HttpClient _httpClient;
     private readonly SettingsService _settings;
-    private readonly LoggingService _logger;
+    private readonly ILogger<OpenAIService> _logger;
 
-    public OpenAIService(HttpClient httpClient, SettingsService settings, LoggingService logger)
+    public OpenAIService(HttpClient httpClient, SettingsService settings, ILogger<OpenAIService> logger)
     {
         _httpClient = httpClient;
         _settings = settings;


### PR DESCRIPTION
## Summary
- inject `ILogger<OpenAIService>` directly and log OpenAI request failures
- remove unused `LoggingService` registration from app startup

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: SuggestionServiceTests.FakeCaptureService.CaptureScreen(): no suitable method found to override)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e3232848328978031d238f86877