### PR TITLE
Add cancellation token support

### DIFF
--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Windows;
 using Microsoft.Extensions.Logging;
 using SpecialGuide.Core.Services;
@@ -23,7 +24,7 @@ public partial class MainWindow : Window
         {
             try
             {
-                await OnMiddleClick(sender, e);
+                await OnMiddleClick(sender, e, CancellationToken.None);
             }
             catch (Exception ex)
             {
@@ -33,10 +34,10 @@ public partial class MainWindow : Window
         _hookService.Start();
     }
 
-    private async Task OnMiddleClick(object? sender, EventArgs e)
+    private async Task OnMiddleClick(object? sender, EventArgs e, CancellationToken cancellationToken)
     {
         var app = _windowService.GetActiveProcessName();
-        var suggestions = await _suggestionService.GetSuggestionsAsync(app);
+        var suggestions = await _suggestionService.GetSuggestionsAsync(app, cancellationToken);
         _overlayService.ShowAtCursor(suggestions);
     }
 }

--- a/src/SpecialGuide.Core/Services/SuggestionService.cs
+++ b/src/SpecialGuide.Core/Services/SuggestionService.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 namespace SpecialGuide.Core.Services;
 
@@ -17,10 +18,10 @@ public class SuggestionService
         _settings = settings;
     }
 
-    public async Task<string[]> GetSuggestionsAsync(string appName)
+    public async Task<string[]> GetSuggestionsAsync(string appName, CancellationToken cancellationToken)
     {
         var image = _capture.CaptureScreen();
-        var suggestions = await _openAI.GenerateSuggestionsAsync(image, appName);
+        var suggestions = await _openAI.GenerateSuggestionsAsync(image, appName, cancellationToken);
         var max = _settings.Settings.MaxSuggestionLength;
         return suggestions.Select(s => s.Length > max ? s[..max] : s).ToArray();
     }

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -1,4 +1,5 @@
 using SpecialGuide.Core.Services;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -13,7 +14,7 @@ public class SuggestionServiceTests
         var openai = new FakeOpenAIService();
         var settings = new SettingsService(new Settings());
         var service = new SuggestionService(capture, openai, settings);
-        var result = await service.GetSuggestionsAsync("app");
+        var result = await service.GetSuggestionsAsync("app", CancellationToken.None);
         Assert.All(result, s => Assert.True(s.Length <= SuggestionService.DefaultMaxSuggestionLength));
     }
 
@@ -24,7 +25,7 @@ public class SuggestionServiceTests
         var openai = new FakeOpenAIService();
         var settings = new SettingsService(new Settings { MaxSuggestionLength = 10 });
         var service = new SuggestionService(capture, openai, settings);
-        var result = await service.GetSuggestionsAsync("app");
+        var result = await service.GetSuggestionsAsync("app", CancellationToken.None);
         Assert.All(result, s => Assert.True(s.Length <= 10));
     }
 
@@ -36,7 +37,7 @@ public class SuggestionServiceTests
     private class FakeOpenAIService : OpenAIService
     {
         public FakeOpenAIService() : base(new SettingsService(new Settings())) { }
-        public override Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
+        public override Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName, CancellationToken cancellationToken)
             => Task.FromResult(new[] { new string('a', 100) });
     }
 }
@@ -58,14 +59,14 @@ namespace SpecialGuide.Core.Services
 
     public class CaptureService
     {
-        public virtual Task<byte[]> CaptureScreenAsync() => Task.FromResult(Array.Empty<byte>());
+        public virtual byte[] CaptureScreen() => Array.Empty<byte>();
     }
 
     public class OpenAIService
     {
         protected readonly SettingsService _settings;
         public OpenAIService(SettingsService settings) => _settings = settings;
-        public virtual Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
+        public virtual Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName, CancellationToken cancellationToken)
             => Task.FromResult(Array.Empty<string>());
     }
 }


### PR DESCRIPTION
## Summary
- Allow OpenAI service calls to accept `CancellationToken` and pass through to `HttpClient.SendAsync`
- Propagate cancellation from suggestion generation up to the main window handler
- Adjust tests for new asynchronous signatures

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689b9e32f9a08328b7b034ef32eab9f5