### PR TITLE
Add structured output parsing for suggestions

### DIFF
--- a/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
+++ b/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using SpecialGuide.Core.Services;
+using Xunit;
+
+namespace SpecialGuide.Tests
+{
+    public class OpenAIServiceTests
+    {
+        [Fact]
+        public async Task Deserializes_StringArray_Content()
+        {
+            var handler = new FakeHandler("{\"choices\":[{\"message\":{\"content\":\"[\\\"one\\\",\\\"two\\\"]\"}}]}");
+            var http = new HttpClient(handler);
+            var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            Assert.Equal(new[] { "one", "two" }, result);
+        }
+
+        [Fact]
+        public async Task Throws_On_Invalid_Json()
+        {
+            var handler = new FakeHandler("{\"choices\":[{\"message\":{\"content\":\"not json\"}}]}");
+            var http = new HttpClient(handler);
+            var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
+            await Assert.ThrowsAsync<JsonException>(() => service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app"));
+        }
+
+        private class FakeHandler : HttpMessageHandler
+        {
+            private readonly string _response;
+            public FakeHandler(string response) => _response = response;
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var message = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_response)
+                };
+                return Task.FromResult(message);
+            }
+        }
+    }
+}
+
+namespace SpecialGuide.Core.Services
+{
+    public class LoggingService
+    {
+        public void LogError(Exception ex, string message) { }
+    }
+}

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -23,7 +23,9 @@
   <ItemGroup>
     <Compile Include="AudioServiceTests.cs" />
     <Compile Include="SuggestionServiceTests.cs" />
+    <Compile Include="OpenAIServiceTests.cs" />
     <Compile Include="..\..\src\SpecialGuide.Core\Services\AudioService.cs" Link="Services/AudioService.cs" />
     <Compile Include="..\..\src\SpecialGuide.Core\Services\SuggestionService.cs" Link="Services/SuggestionService.cs" />
+    <Compile Include="..\..\src\SpecialGuide.Core\Services\OpenAIService.cs" Link="Services/OpenAIService.cs" />
   </ItemGroup>
 </Project>

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -35,7 +35,7 @@ public class SuggestionServiceTests
 
     private class FakeOpenAIService : OpenAIService
     {
-        public FakeOpenAIService() : base(new SettingsService(new Settings())) { }
+        public FakeOpenAIService() : base(new HttpClient(), new SettingsService(new Settings()), new LoggingService()) { }
         public override Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
             => Task.FromResult(new[] { new string('a', 100) });
     }
@@ -48,24 +48,18 @@ namespace SpecialGuide.Core.Services
     public class SettingsService
     {
         public Settings Settings { get; }
+        public string ApiKey => Settings.ApiKey;
         public SettingsService(Settings settings) => Settings = settings;
     }
 
     public class Settings
     {
         public int MaxSuggestionLength { get; set; } = SuggestionService.DefaultMaxSuggestionLength;
+        public string ApiKey { get; set; } = string.Empty;
     }
 
     public class CaptureService
     {
-        public virtual Task<byte[]> CaptureScreenAsync() => Task.FromResult(Array.Empty<byte>());
-    }
-
-    public class OpenAIService
-    {
-        protected readonly SettingsService _settings;
-        public OpenAIService(SettingsService settings) => _settings = settings;
-        public virtual Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
-            => Task.FromResult(Array.Empty<string>());
+        public virtual byte[] CaptureScreen() => Array.Empty<byte>();
     }
 }


### PR DESCRIPTION
## Summary
- request structured `string[]` suggestions via OpenAI `response_format`
- parse suggestion content with direct `JsonSerializer.Deserialize<string[]>`
- add unit tests covering successful parse and invalid JSON failure

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689b9e33909883288e7f4ea8fa47591f