### PR TITLE
Add hook stop logic and tests

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -46,6 +46,8 @@ public partial class App : Application
     {
         if (_host != null && _cts != null)
         {
+            var hookService = _host.Services.GetService<HookService>();
+            hookService?.Stop();
             await _host.StopAsync(_cts.Token);
             _host.Dispose();
             _cts.Dispose();

--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ public partial class MainWindow : Window
             }
         };
         _hookService.Start();
+        Closed += (_, _) => _hookService.Stop();
     }
 
     private async Task OnMiddleClick(object? sender, EventArgs e)

--- a/src/SpecialGuide.Core/Services/HookService.cs
+++ b/src/SpecialGuide.Core/Services/HookService.cs
@@ -10,11 +10,27 @@ public class HookService : IDisposable
 
     public event EventHandler? MiddleClick;
 
-    public void Start() => _hookId = SetHook(HookCallback);
+    public void Start()
+    {
+        _hookId = SetHook(HookCallback);
+        if (_hookId == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("Failed to set Windows hook");
+        }
+    }
+
+    public void Stop()
+    {
+        if (_hookId != IntPtr.Zero)
+        {
+            UnhookWindowsHookEx(_hookId);
+            _hookId = IntPtr.Zero;
+        }
+    }
 
     public void SetOverlayVisible(bool visible) => _overlayVisible = visible;
 
-    public void Dispose() => UnhookWindowsHookEx(_hookId);
+    public void Dispose() => Stop();
 
     private IntPtr SetHook(HookProc proc)
     {

--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -1,0 +1,27 @@
+using SpecialGuide.Core.Services;
+using Xunit;
+
+namespace SpecialGuide.Tests;
+
+public class HookServiceTests
+{
+    [Fact]
+    public void StartStop_Repeated_Cycles_Safe()
+    {
+        var service = new HookService();
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Throws<DllNotFoundException>(() => service.Start());
+            return;
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            service.Start();
+            service.Stop();
+        }
+
+        var field = typeof(HookService).GetField("_hookId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.Equal(IntPtr.Zero, (IntPtr)field!.GetValue(service)!);
+    }
+}

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -25,5 +25,6 @@
     <Compile Include="SuggestionServiceTests.cs" />
     <Compile Include="..\..\src\SpecialGuide.Core\Services\AudioService.cs" Link="Services/AudioService.cs" />
     <Compile Include="..\..\src\SpecialGuide.Core\Services\SuggestionService.cs" Link="Services/SuggestionService.cs" />
+    <Compile Include="..\..\src\SpecialGuide.Core\Services\HookService.cs" Link="Services/HookService.cs" />
   </ItemGroup>
 </Project>

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -58,7 +58,7 @@ namespace SpecialGuide.Core.Services
 
     public class CaptureService
     {
-        public virtual Task<byte[]> CaptureScreenAsync() => Task.FromResult(Array.Empty<byte>());
+        public virtual byte[] CaptureScreen() => Array.Empty<byte>();
     }
 
     public class OpenAIService


### PR DESCRIPTION
## Summary
- guard HookService.Start against SetWindowsHookEx failures
- add Stop method to unhook and reset state
- stop HookService on MainWindow close and application exit
- test repeated start/stop cycles

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689b9e348ff083289e6ea754b93e367f