### PR TITLE
feat: add settings window and file-based settings

### DIFF
--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -1,0 +1,14 @@
+<Window x:Class="SpecialGuide.App.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" Height="220" Width="300">
+    <StackPanel Margin="10">
+        <TextBlock Text="API Key" />
+        <TextBox Text="{Binding ApiKey}" Margin="0,0,0,10" />
+        <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
+        <TextBlock Text="Max Suggestion Length" />
+        <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />
+        <Button Content="Save" HorizontalAlignment="Right" Width="80" Click="OnSave" />
+    </StackPanel>
+</Window>
+

--- a/src/SpecialGuide.App/SettingsWindow.xaml.cs
+++ b/src/SpecialGuide.App/SettingsWindow.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows;
+using SpecialGuide.Core.Services;
+
+namespace SpecialGuide.App;
+
+public partial class SettingsWindow : Window
+{
+    private readonly SettingsService _settings;
+
+    public SettingsWindow(SettingsService settings)
+    {
+        InitializeComponent();
+        _settings = settings;
+        DataContext = _settings.Settings;
+    }
+
+    private void OnSave(object sender, RoutedEventArgs e)
+    {
+        _settings.Save();
+        Close();
+    }
+}
+

--- a/src/SpecialGuide.App/SpecialGuide.App.csproj
+++ b/src/SpecialGuide.App/SpecialGuide.App.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableUnsafeBlocks>true</EnableUnsafeBlocks>


### PR DESCRIPTION
## Summary
- persist settings under `%AppData%/SpecialGuide/appsettings.json` and watch for live changes
- add WPF settings dialog for API key, auto paste, and max suggestion length
- expose settings via tray icon

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: The type or namespace name 'OpenAIService' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_689be7db5c408328ab0699a2ff9338af