### PR TITLE
Add resilient OpenAI suggestion handling

### DIFF
--- a/src/SpecialGuide.Core/Services/SuggestionService.cs
+++ b/src/SpecialGuide.Core/Services/SuggestionService.cs
@@ -20,8 +20,8 @@ public class SuggestionService
     public async Task<string[]> GetSuggestionsAsync(string appName)
     {
         var image = _capture.CaptureScreen();
-        var suggestions = await _openAI.GenerateSuggestionsAsync(image, appName);
+        var result = await _openAI.GenerateSuggestionsAsync(image, appName);
         var max = _settings.Settings.MaxSuggestionLength;
-        return suggestions.Select(s => s.Length > max ? s[..max] : s).ToArray();
+        return result.Suggestions.Select(s => s.Length > max ? s[..max] : s).ToArray();
     }
 }

--- a/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
+++ b/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using SpecialGuide.Core.Services;
 using Xunit;
 
@@ -17,16 +19,57 @@ namespace SpecialGuide.Tests
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
             var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
-            Assert.Equal(new[] { "one", "two" }, result);
+            Assert.Equal(new[] { "one", "two" }, result.Suggestions);
+            Assert.Null(result.Error);
         }
 
         [Fact]
-        public async Task Throws_On_Invalid_Json()
+        public async Task Returns_Error_On_Invalid_Json()
         {
             var handler = new FakeHandler("{\"choices\":[{\"message\":{\"content\":\"not json\"}}]}");
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
-            await Assert.ThrowsAsync<JsonException>(() => service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app"));
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            Assert.NotNull(result.Error);
+            Assert.Empty(result.Suggestions);
+        }
+
+        [Fact]
+        public async Task Retries_On_429_Then_Succeeds()
+        {
+            var responses = new[]
+            {
+                new HttpResponseMessage((HttpStatusCode)429),
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"choices\":[{\"message\":{\"content\":\"[]\"}}]}")
+                }
+            };
+            var handler = new SequenceHandler(responses);
+            var http = new HttpClient(handler);
+            var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            Assert.Equal(2, handler.Calls);
+            Assert.Empty(result.Suggestions);
+            Assert.Null(result.Error);
+        }
+
+        [Fact]
+        public async Task Gives_Up_After_Retries()
+        {
+            var responses = new[]
+            {
+                new HttpResponseMessage(HttpStatusCode.InternalServerError),
+                new HttpResponseMessage(HttpStatusCode.InternalServerError),
+                new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            };
+            var handler = new SequenceHandler(responses);
+            var http = new HttpClient(handler);
+            var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            Assert.Equal(3, handler.Calls);
+            Assert.Empty(result.Suggestions);
+            Assert.NotNull(result.Error);
         }
 
         private class FakeHandler : HttpMessageHandler
@@ -42,13 +85,29 @@ namespace SpecialGuide.Tests
                 return Task.FromResult(message);
             }
         }
+
+        private class SequenceHandler : HttpMessageHandler
+        {
+            private readonly Queue<HttpResponseMessage> _responses;
+            public int Calls { get; private set; }
+            public SequenceHandler(IEnumerable<HttpResponseMessage> responses) => _responses = new Queue<HttpResponseMessage>(responses);
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Calls++;
+                return Task.FromResult(_responses.Dequeue());
+            }
+        }
     }
 }
 
 namespace SpecialGuide.Core.Services
 {
-    public class LoggingService
+    public class LoggingService : ILogger<OpenAIService>
     {
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
         public void LogError(Exception ex, string message) { }
+        private class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
     }
 }

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AudioServiceTests.cs" />
@@ -26,6 +27,7 @@
     <Compile Include="OpenAIServiceTests.cs" />
     <Compile Include="..\..\src\SpecialGuide.Core\Services\AudioService.cs" Link="Services/AudioService.cs" />
     <Compile Include="..\..\src\SpecialGuide.Core\Services\SuggestionService.cs" Link="Services/SuggestionService.cs" />
+    <Compile Include="..\..\src\SpecialGuide.Core\Services\OpenAIService.cs" Link="Services/OpenAIService.cs" />
 
   </ItemGroup>
 </Project>

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -36,8 +36,8 @@ public class SuggestionServiceTests
     private class FakeOpenAIService : OpenAIService
     {
         public FakeOpenAIService() : base(new HttpClient(), new SettingsService(new Settings()), new LoggingService()) { }
-        public override Task<string[]> GenerateSuggestionsAsync(byte[] image, string appName)
-            => Task.FromResult(new[] { new string('a', 100) });
+        public override Task<SuggestionResult> GenerateSuggestionsAsync(byte[] image, string appName)
+            => Task.FromResult(new SuggestionResult(new[] { new string('a', 100) }, null));
     }
 }
 


### PR DESCRIPTION
## Summary
- add retry/backoff and structured `SuggestionResult` with error details
- return empty suggestions on persistent failure instead of throwing
- test 429/500 responses and malformed JSON paths

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_689be7dbaa8083289f182dd3ab7dff7a