### PR TITLE
feat: add configurable hotkey

### DIFF
--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -19,22 +19,22 @@ public partial class MainWindow : Window
         _suggestionService = suggestionService;
         _windowService = windowService;
         _logger = logger;
-        _hookService.MiddleClick += async (sender, e) =>
+        _hookService.HotkeyPressed += async (sender, e) =>
         {
             try
             {
-                await OnMiddleClick(sender, e);
+                await OnHotkeyPressed(sender, e);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error handling middle click");
+                _logger.LogError(ex, "Error handling hotkey");
             }
         };
         _hookService.Start();
         Closed += (_, _) => _hookService.Stop();
     }
 
-    private async Task OnMiddleClick(object? sender, EventArgs e)
+    private async Task OnHotkeyPressed(object? sender, EventArgs e)
     {
         var app = _windowService.GetActiveProcessName();
         var suggestions = await _suggestionService.GetSuggestionsAsync(app);

--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -8,6 +8,8 @@
         <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
         <TextBlock Text="Max Suggestion Length" />
         <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />
+        <TextBlock Text="Hotkey" />
+        <TextBox x:Name="HotkeyBox" Text="{Binding Hotkey}" Margin="0,0,0,10" PreviewKeyDown="OnHotkeyKeyDown" />
         <Button Content="Save" HorizontalAlignment="Right" Width="80" Click="OnSave" />
     </StackPanel>
 </Window>

--- a/src/SpecialGuide.App/SettingsWindow.xaml.cs
+++ b/src/SpecialGuide.App/SettingsWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Input;
 using SpecialGuide.Core.Services;
 
 namespace SpecialGuide.App;
@@ -14,8 +15,32 @@ public partial class SettingsWindow : Window
         DataContext = _settings.Settings;
     }
 
+    private void OnHotkeyKeyDown(object sender, KeyEventArgs e)
+    {
+        e.Handled = true;
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        if (key == Key.Escape)
+        {
+            HotkeyBox.Text = string.Empty;
+            _settings.Settings.Hotkey = string.Empty;
+            return;
+        }
+        var hotkey = string.Empty;
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control)) hotkey += "Control+";
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift)) hotkey += "Shift+";
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt)) hotkey += "Alt+";
+        hotkey += key.ToString();
+        HotkeyBox.Text = hotkey;
+        _settings.Settings.Hotkey = hotkey;
+    }
+
     private void OnSave(object sender, RoutedEventArgs e)
     {
+        if (!HookService.TryParseHotkey(_settings.Settings.Hotkey, out var parsed) || HookService.IsReservedHotkey(parsed))
+        {
+            MessageBox.Show("Hotkey is reserved or invalid. Falling back to middle click.", "Invalid hotkey", MessageBoxButton.OK, MessageBoxImage.Warning);
+            _settings.Settings.Hotkey = string.Empty;
+        }
         _settings.Save();
         Close();
     }

--- a/src/SpecialGuide.Core/Models/Settings.cs
+++ b/src/SpecialGuide.Core/Models/Settings.cs
@@ -5,4 +5,5 @@ public class Settings
     public string ApiKey { get; set; } = string.Empty;
     public bool AutoPaste { get; set; }
     public int MaxSuggestionLength { get; set; } = SpecialGuide.Core.Services.SuggestionService.DefaultMaxSuggestionLength;
+    public string Hotkey { get; set; } = string.Empty;
 }

--- a/src/SpecialGuide.Core/Services/HookService.cs
+++ b/src/SpecialGuide.Core/Services/HookService.cs
@@ -1,23 +1,35 @@
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace SpecialGuide.Core.Services;
 
 public class HookService : IDisposable
 {
+    private readonly SettingsService _settings;
     private IntPtr _hookId = IntPtr.Zero;
     private HookProc? _proc;
+    private Keys _hotkey = Keys.None;
     private bool _overlayVisible;
 
-    public event EventHandler? MiddleClick;
+    public event EventHandler? HotkeyPressed;
 
-    public void Start()
+    public HookService(SettingsService settings)
     {
-        _hookId = SetHook(HookCallback);
-        if (_hookId == IntPtr.Zero)
+        _settings = settings;
+        _settings.SettingsChanged += _ =>
         {
-            throw new InvalidOperationException("Failed to set Windows hook");
-        }
+            try
+            {
+                Reload();
+            }
+            catch
+            {
+                // ignore reload failures
+            }
+        };
     }
+
+    public void Start() => Reload();
 
     public void Stop()
     {
@@ -28,35 +40,122 @@ public class HookService : IDisposable
         }
     }
 
+    private void Reload()
+    {
+        Stop();
+        var hotkeyString = _settings.Settings.Hotkey;
+        if (TryParseHotkey(hotkeyString, out var keys) && !IsReservedHotkey(keys))
+        {
+            _hotkey = keys;
+            _hookId = SetHook(KeyboardCallback, WH_KEYBOARD_LL);
+        }
+        else
+        {
+            _hotkey = Keys.None;
+            _hookId = SetHook(MouseCallback, WH_MOUSE_LL);
+        }
+        if (_hookId == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("Failed to set Windows hook");
+        }
+    }
+
     public void SetOverlayVisible(bool visible) => _overlayVisible = visible;
 
     public void Dispose() => Stop();
 
-    private IntPtr SetHook(HookProc proc)
+    private IntPtr SetHook(HookProc proc, int idHook)
     {
         _proc = proc;
         using var curProcess = System.Diagnostics.Process.GetCurrentProcess();
         using var curModule = curProcess.MainModule!;
-        return SetWindowsHookEx(WH_MOUSE_LL, proc, GetModuleHandle(curModule.ModuleName), 0);
+        return SetWindowsHookEx(idHook, proc, GetModuleHandle(curModule.ModuleName), 0);
     }
 
-    private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    private IntPtr MouseCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
         const int WM_MBUTTONDOWN = 0x0207;
         if (nCode >= 0 && wParam == (IntPtr)WM_MBUTTONDOWN)
         {
-            MiddleClick?.Invoke(this, EventArgs.Empty);
+            HotkeyPressed?.Invoke(this, EventArgs.Empty);
             if (_overlayVisible)
             {
-                return new IntPtr(1); // suppress
+                return new IntPtr(1);
             }
         }
         return CallNextHookEx(_hookId, nCode, wParam, lParam);
     }
 
+    private IntPtr KeyboardCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        const int WM_KEYDOWN = 0x0100;
+        if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
+        {
+            var kb = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
+            if (kb.HasValue)
+            {
+                var key = (Keys)kb.Value.vkCode;
+                var mods = Keys.None;
+                if (IsKeyPressed(VK_CONTROL)) mods |= Keys.Control;
+                if (IsKeyPressed(VK_SHIFT)) mods |= Keys.Shift;
+                if (IsKeyPressed(VK_MENU)) mods |= Keys.Alt;
+                var current = mods | key;
+                if (current == _hotkey)
+                {
+                    HotkeyPressed?.Invoke(this, EventArgs.Empty);
+                    if (_overlayVisible)
+                    {
+                        return new IntPtr(1);
+                    }
+                }
+            }
+        }
+        return CallNextHookEx(_hookId, nCode, wParam, lParam);
+    }
+
+    public static bool TryParseHotkey(string? hotkey, out Keys result)
+    {
+        result = Keys.None;
+        if (string.IsNullOrWhiteSpace(hotkey))
+            return false;
+        var formatted = hotkey.Replace('+', ',');
+        if (!Enum.TryParse(formatted, true, out result))
+            return false;
+        var key = result & Keys.KeyCode;
+        if (key == Keys.None || key == Keys.ControlKey || key == Keys.ShiftKey || key == Keys.Menu)
+            return false;
+        return true;
+    }
+
+    private static readonly Keys[] ReservedHotkeys =
+    {
+        Keys.Alt | Keys.Tab,
+        Keys.Alt | Keys.F4,
+        Keys.Control | Keys.Alt | Keys.Delete,
+        Keys.Control | Keys.Shift | Keys.Escape
+    };
+
+    public static bool IsReservedHotkey(Keys hotkey) => Array.IndexOf(ReservedHotkeys, hotkey) >= 0;
+
+    private static bool IsKeyPressed(int key) => (GetKeyState(key) & 0x8000) != 0;
+
     private delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 
     private const int WH_MOUSE_LL = 14;
+    private const int WH_KEYBOARD_LL = 13;
+    private const int VK_SHIFT = 0x10;
+    private const int VK_CONTROL = 0x11;
+    private const int VK_MENU = 0x12;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KBDLLHOOKSTRUCT
+    {
+        public int vkCode;
+        public int scanCode;
+        public int flags;
+        public int time;
+        public IntPtr dwExtraInfo;
+    }
 
     [DllImport("user32.dll")]
     private static extern IntPtr SetWindowsHookEx(int idHook, HookProc lpfn, IntPtr hMod, uint dwThreadId);
@@ -69,4 +168,7 @@ public class HookService : IDisposable
 
     [DllImport("kernel32.dll")]
     private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+    [DllImport("user32.dll")]
+    private static extern short GetKeyState(int nVirtKey);
 }

--- a/src/SpecialGuide.Core/SpecialGuide.Core.csproj
+++ b/src/SpecialGuide.Core/SpecialGuide.Core.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -1,3 +1,4 @@
+using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 using Xunit;
 
@@ -8,7 +9,8 @@ public class HookServiceTests
     [Fact]
     public void StartStop_Repeated_Cycles_Safe()
     {
-        var service = new HookService();
+        using var settings = new SettingsService(new Settings());
+        var service = new HookService(settings);
         if (!OperatingSystem.IsWindows())
         {
             Assert.Throws<DllNotFoundException>(() => service.Start());


### PR DESCRIPTION
## Summary
- add Hotkey setting and expose it in settings UI
- handle keyboard hotkey via HookService with middle-click fallback
- reload hook when settings change

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: SpecialGuide.Tests.AudioServiceTests.Stop_Disposes_Resources)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e048e48832896b33478b9b3bd05