### PR TITLE
feat: add configurable activation hotkey

### DIFF
--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -1,13 +1,15 @@
 <Window x:Class="SpecialGuide.App.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Settings" Height="220" Width="300">
+        Title="Settings" Height="260" Width="300">
     <StackPanel Margin="10">
         <TextBlock Text="API Key" />
         <TextBox Text="{Binding ApiKey}" Margin="0,0,0,10" />
         <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
         <TextBlock Text="Max Suggestion Length" />
         <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />
+        <TextBlock Text="Activation Hotkey" />
+        <TextBox Text="{Binding ActivationHotkey}" Margin="0,0,0,10" />
         <Button Content="Save" HorizontalAlignment="Right" Width="80" Click="OnSave" />
     </StackPanel>
 </Window>

--- a/src/SpecialGuide.App/SettingsWindow.xaml.cs
+++ b/src/SpecialGuide.App/SettingsWindow.xaml.cs
@@ -6,17 +6,23 @@ namespace SpecialGuide.App;
 public partial class SettingsWindow : Window
 {
     private readonly SettingsService _settings;
+    private readonly HookService _hookService;
 
-    public SettingsWindow(SettingsService settings)
+    public SettingsWindow(SettingsService settings, HookService hookService)
     {
         InitializeComponent();
         _settings = settings;
+        _hookService = hookService;
         DataContext = _settings.Settings;
     }
 
     private void OnSave(object sender, RoutedEventArgs e)
     {
         _settings.Save();
+        if (!_hookService.Reload())
+        {
+            MessageBox.Show("Hotkey registration failed. Using middle-click instead.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
         Close();
     }
 }

--- a/src/SpecialGuide.Core/Models/Settings.cs
+++ b/src/SpecialGuide.Core/Models/Settings.cs
@@ -5,4 +5,5 @@ public class Settings
     public string ApiKey { get; set; } = string.Empty;
     public bool AutoPaste { get; set; }
     public int MaxSuggestionLength { get; set; } = SpecialGuide.Core.Services.SuggestionService.DefaultMaxSuggestionLength;
+    public string ActivationHotkey { get; set; } = string.Empty;
 }

--- a/src/SpecialGuide.Core/Services/HookService.cs
+++ b/src/SpecialGuide.Core/Services/HookService.cs
@@ -1,30 +1,72 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace SpecialGuide.Core.Services;
 
 public class HookService : IDisposable
 {
-    private IntPtr _hookId = IntPtr.Zero;
-    private HookProc? _proc;
+    private IntPtr _mouseHookId = IntPtr.Zero;
+    private IntPtr _keyboardHookId = IntPtr.Zero;
+    private HookProc? _mouseProc;
+    private HookProc? _keyboardProc;
+    private readonly SettingsService _settings;
     private bool _overlayVisible;
+    private Modifiers _hotkeyModifiers;
+    private uint _hotkeyKey;
+    private Modifiers _currentModifiers;
+
+    internal bool IsMouseHookActive => _mouseHookId != IntPtr.Zero;
+    internal bool IsKeyboardHookActive => _keyboardHookId != IntPtr.Zero;
 
     public event EventHandler? MiddleClick;
 
-    public void Start()
+    public HookService(SettingsService settings)
     {
-        _hookId = SetHook(HookCallback);
-        if (_hookId == IntPtr.Zero)
+        _settings = settings;
+    }
+
+    public void Start() => Reload();
+
+    /// <summary>
+    /// Reloads the hook registration. Returns true if the configured hotkey was registered,
+    /// false if the service fell back to the middle mouse button.
+    /// </summary>
+    public bool Reload()
+    {
+        Stop();
+        var hotkey = _settings.Settings.ActivationHotkey;
+        if (!string.IsNullOrWhiteSpace(hotkey) &&
+            TryParseHotkey(hotkey, out _hotkeyModifiers, out _hotkeyKey, out var _))
         {
-            throw new InvalidOperationException("Failed to set Windows hook");
+            _keyboardProc = KeyboardHookCallback;
+            _keyboardHookId = SetHook(WH_KEYBOARD_LL, _keyboardProc);
+            if (_keyboardHookId != IntPtr.Zero)
+            {
+                return true;
+            }
+            Warn($"Failed to register hotkey '{hotkey}', falling back to middle click.");
         }
+
+        _mouseProc = MouseHookCallback;
+        _mouseHookId = SetHook(WH_MOUSE_LL, _mouseProc);
+        if (_mouseHookId == IntPtr.Zero)
+        {
+            Warn("Failed to register middle-click hook");
+        }
+        return false;
     }
 
     public void Stop()
     {
-        if (_hookId != IntPtr.Zero)
+        if (_keyboardHookId != IntPtr.Zero)
         {
-            UnhookWindowsHookEx(_hookId);
-            _hookId = IntPtr.Zero;
+            Unhook(_keyboardHookId);
+            _keyboardHookId = IntPtr.Zero;
+        }
+        if (_mouseHookId != IntPtr.Zero)
+        {
+            Unhook(_mouseHookId);
+            _mouseHookId = IntPtr.Zero;
         }
     }
 
@@ -32,15 +74,16 @@ public class HookService : IDisposable
 
     public void Dispose() => Stop();
 
-    private IntPtr SetHook(HookProc proc)
+    protected virtual IntPtr SetHook(int idHook, HookProc proc)
     {
-        _proc = proc;
-        using var curProcess = System.Diagnostics.Process.GetCurrentProcess();
+        using var curProcess = Process.GetCurrentProcess();
         using var curModule = curProcess.MainModule!;
-        return SetWindowsHookEx(WH_MOUSE_LL, proc, GetModuleHandle(curModule.ModuleName), 0);
+        return SetWindowsHookEx(idHook, proc, GetModuleHandle(curModule.ModuleName), 0);
     }
 
-    private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    protected virtual bool Unhook(IntPtr hookId) => UnhookWindowsHookEx(hookId);
+
+    private IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
         const int WM_MBUTTONDOWN = 0x0207;
         if (nCode >= 0 && wParam == (IntPtr)WM_MBUTTONDOWN)
@@ -51,12 +94,166 @@ public class HookService : IDisposable
                 return new IntPtr(1); // suppress
             }
         }
-        return CallNextHookEx(_hookId, nCode, wParam, lParam);
+        return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
     }
 
-    private delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
+    private IntPtr KeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        const int WM_KEYDOWN = 0x0100;
+        const int WM_KEYUP = 0x0101;
+        const int WM_SYSKEYDOWN = 0x0104;
+        const int WM_SYSKEYUP = 0x0105;
+        if (nCode >= 0)
+        {
+            var data = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
+            switch ((int)wParam)
+            {
+                case WM_KEYDOWN:
+                case WM_SYSKEYDOWN:
+                    UpdateModifiers((int)data.vkCode, true);
+                    if (data.vkCode == _hotkeyKey && _currentModifiers == _hotkeyModifiers)
+                    {
+                        MiddleClick?.Invoke(this, EventArgs.Empty);
+                        if (_overlayVisible)
+                        {
+                            return new IntPtr(1);
+                        }
+                    }
+                    break;
+                case WM_KEYUP:
+                case WM_SYSKEYUP:
+                    UpdateModifiers((int)data.vkCode, false);
+                    break;
+            }
+        }
+        return CallNextHookEx(_keyboardHookId, nCode, wParam, lParam);
+    }
 
-    private const int WH_MOUSE_LL = 14;
+    private void UpdateModifiers(int vkCode, bool down)
+    {
+        void Set(ref Modifiers mods, Modifiers flag, bool value)
+        {
+            if (value) mods |= flag;
+            else mods &= ~flag;
+        }
+
+        switch (vkCode)
+        {
+            case 0x10: // SHIFT
+            case 0xA0:
+            case 0xA1:
+                Set(ref _currentModifiers, Modifiers.Shift, down);
+                break;
+            case 0x11: // CTRL
+            case 0xA2:
+            case 0xA3:
+                Set(ref _currentModifiers, Modifiers.Control, down);
+                break;
+            case 0x12: // ALT
+            case 0xA4:
+            case 0xA5:
+                Set(ref _currentModifiers, Modifiers.Alt, down);
+                break;
+            case 0x5B: // LWIN
+            case 0x5C: // RWIN
+                Set(ref _currentModifiers, Modifiers.Win, down);
+                break;
+        }
+    }
+
+    private static bool TryParseHotkey(string hotkey, out Modifiers modifiers, out uint key, out string? error)
+    {
+        modifiers = Modifiers.None;
+        key = 0;
+        error = null;
+        var parts = hotkey.Split('+', StringSplitOptions.RemoveEmptyEntries);
+        bool keySet = false;
+        foreach (var part in parts)
+        {
+            var token = part.Trim().ToUpperInvariant();
+            switch (token)
+            {
+                case "CTRL":
+                case "CONTROL":
+                    if (modifiers.HasFlag(Modifiers.Control)) { error = "Duplicate modifier"; return false; }
+                    modifiers |= Modifiers.Control;
+                    break;
+                case "ALT":
+                    if (modifiers.HasFlag(Modifiers.Alt)) { error = "Duplicate modifier"; return false; }
+                    modifiers |= Modifiers.Alt;
+                    break;
+                case "SHIFT":
+                    if (modifiers.HasFlag(Modifiers.Shift)) { error = "Duplicate modifier"; return false; }
+                    modifiers |= Modifiers.Shift;
+                    break;
+                case "WIN":
+                case "WINDOWS":
+                case "META":
+                    if (modifiers.HasFlag(Modifiers.Win)) { error = "Duplicate modifier"; return false; }
+                    modifiers |= Modifiers.Win;
+                    break;
+                default:
+                    if (keySet) { error = "Multiple keys"; return false; }
+                    if (token.Length == 1)
+                    {
+                        key = (uint)token[0];
+                    }
+                    else if (token.StartsWith("F") && int.TryParse(token.Substring(1), out var fn) && fn >= 1 && fn <= 12)
+                    {
+                        key = (uint)(0x70 + fn - 1);
+                    }
+                    else if (token == "DELETE")
+                    {
+                        key = 0x2E;
+                    }
+                    else
+                    {
+                        error = $"Unknown key '{part}'";
+                        return false;
+                    }
+                    keySet = true;
+                    break;
+            }
+        }
+        if (!keySet)
+        {
+            error = "No key specified";
+            return false;
+        }
+        if (modifiers == (Modifiers.Control | Modifiers.Alt) && key == 0x2E)
+        {
+            error = "Reserved combination";
+            return false;
+        }
+        return true;
+    }
+
+    private static void Warn(string message) => Console.Error.WriteLine(message);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KBDLLHOOKSTRUCT
+    {
+        public uint vkCode;
+        public uint scanCode;
+        public uint flags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [Flags]
+    private enum Modifiers
+    {
+        None = 0,
+        Control = 1,
+        Alt = 2,
+        Shift = 4,
+        Win = 8,
+    }
+
+    protected delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    internal const int WH_KEYBOARD_LL = 13;
+    internal const int WH_MOUSE_LL = 14;
 
     [DllImport("user32.dll")]
     private static extern IntPtr SetWindowsHookEx(int idHook, HookProc lpfn, IntPtr hMod, uint dwThreadId);

--- a/src/SpecialGuide.Core/Services/SettingsService.cs
+++ b/src/SpecialGuide.Core/Services/SettingsService.cs
@@ -13,6 +13,7 @@ public class SettingsService : IDisposable
 
     public Settings Settings => _settings;
     public string ApiKey => _settings.ApiKey;
+    public string ActivationHotkey => _settings.ActivationHotkey;
 
     public event Action<Settings>? SettingsChanged;
 

--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -1,4 +1,5 @@
 using SpecialGuide.Core.Services;
+using SpecialGuide.Core.Models;
 using Xunit;
 
 namespace SpecialGuide.Tests;
@@ -6,22 +7,65 @@ namespace SpecialGuide.Tests;
 public class HookServiceTests
 {
     [Fact]
-    public void StartStop_Repeated_Cycles_Safe()
+    public void Registers_Keyboard_Hook_When_Hotkey_Configured()
     {
-        var service = new HookService();
-        if (!OperatingSystem.IsWindows())
+        var settings = new SettingsService(new Settings { ActivationHotkey = "Ctrl+Alt+H" });
+        var service = new TestHookService(settings);
+        service.Start();
+        Assert.Equal(1, service.KeyboardHookCount);
+        Assert.Equal(0, service.MouseHookCount);
+    }
+
+    [Fact]
+    public void Falls_Back_To_Mouse_When_Keyboard_Fails()
+    {
+        var settings = new SettingsService(new Settings { ActivationHotkey = "Ctrl+Alt+H" });
+        var service = new TestHookService(settings) { KeyboardShouldFail = true };
+        service.Start();
+        Assert.Equal(0, service.KeyboardHookCount);
+        Assert.Equal(1, service.MouseHookCount);
+    }
+
+    [Fact]
+    public void Stop_Unhooks_All()
+    {
+        var settings = new SettingsService(new Settings());
+        var service = new TestHookService(settings);
+        service.Start();
+        service.Stop();
+        Assert.Equal(0, service.KeyboardHookCount);
+        Assert.Equal(0, service.MouseHookCount);
+    }
+
+    private class TestHookService : HookService
+    {
+        public int MouseHookCount { get; private set; }
+        public int KeyboardHookCount { get; private set; }
+        public bool KeyboardShouldFail { get; set; }
+
+        public TestHookService(SettingsService settings) : base(settings) { }
+
+        protected override IntPtr SetHook(int idHook, HookProc proc)
         {
-            Assert.Throws<DllNotFoundException>(() => service.Start());
-            return;
+            if (idHook == WH_KEYBOARD_LL)
+            {
+                if (KeyboardShouldFail) return IntPtr.Zero;
+                KeyboardHookCount++;
+                return new IntPtr(1);
+            }
+            else if (idHook == WH_MOUSE_LL)
+            {
+                MouseHookCount++;
+                return new IntPtr(2);
+            }
+            return IntPtr.Zero;
         }
 
-        for (int i = 0; i < 3; i++)
+        protected override bool Unhook(IntPtr hookId)
         {
-            service.Start();
-            service.Stop();
+            if (hookId == new IntPtr(1)) KeyboardHookCount--;
+            if (hookId == new IntPtr(2)) MouseHookCount--;
+            return true;
         }
-
-        var field = typeof(HookService).GetField("_hookId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        Assert.Equal(IntPtr.Zero, (IntPtr)field!.GetValue(service)!);
     }
 }


### PR DESCRIPTION
## Summary
- add `ActivationHotkey` to settings and expose through service
- register hotkey via `HookService` with middle-click fallback
- allow editing hotkey in settings window and reload hook
- test hotkey registration, fallback and cleanup via mocked hooks

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Unable to find package Gma.System.MouseKeyHook)*

------
https://chatgpt.com/codex/tasks/task_e_689c892f13ac832880be179758f7a386