### PR TITLE
Add cancellable suggestion loading with overlay spinner

### DIFF
--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Windows;
 using Microsoft.Extensions.Logging;
 using SpecialGuide.Core.Services;
@@ -11,6 +13,8 @@ public partial class MainWindow : Window
     private readonly SuggestionService _suggestionService;
     private readonly WindowService _windowService;
     private readonly ILogger<MainWindow> _logger;
+    private bool _busy;
+    private CancellationTokenSource? _cts;
     public MainWindow(HookService hookService, OverlayService overlayService, SuggestionService suggestionService, WindowService windowService, ILogger<MainWindow> logger)
     {
         InitializeComponent();
@@ -19,6 +23,7 @@ public partial class MainWindow : Window
         _suggestionService = suggestionService;
         _windowService = windowService;
         _logger = logger;
+        _overlayService.CancelRequested += (_, _) => CancelActive();
         _hookService.MiddleClick += async (sender, e) =>
         {
             try
@@ -36,8 +41,37 @@ public partial class MainWindow : Window
 
     private async Task OnMiddleClick(object? sender, EventArgs e)
     {
-        var app = _windowService.GetActiveProcessName();
-        var suggestions = await _suggestionService.GetSuggestionsAsync(app);
-        _overlayService.ShowAtCursor(suggestions);
+        if (_busy) return;
+        _busy = true;
+        _cts = new CancellationTokenSource();
+        _overlayService.ShowLoadingAtCursor();
+        try
+        {
+            var app = _windowService.GetActiveProcessName();
+            var result = await _suggestionService.GetSuggestionsAsync(app, _cts.Token);
+            if (result.Error != null)
+            {
+                MessageBox.Show(result.Error, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                _overlayService.Hide();
+            }
+            else
+            {
+                _overlayService.ShowSuggestions(result.Suggestions);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _overlayService.Hide();
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private void CancelActive()
+    {
+        if (!_busy) return;
+        _cts?.Cancel();
     }
 }

--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml
@@ -2,9 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         WindowStyle="None" AllowsTransparency="True" Background="Transparent"
-        ShowInTaskbar="False" Topmost="True" SizeToContent="WidthAndHeight">
+        ShowInTaskbar="False" Topmost="True" SizeToContent="WidthAndHeight" Focusable="True">
     <Canvas x:Name="RootCanvas" Width="200" Height="200">
         <Button x:Name="MicButton" Content="🎤" Width="40" Height="40"/>
+        <ProgressBar x:Name="Spinner" Width="60" Height="10" IsIndeterminate="True" Visibility="Collapsed"/>
+        <Button x:Name="CancelButton" Content="✖" Width="30" Height="30" Visibility="Collapsed"/>
         <!-- Items added dynamically -->
     </Canvas>
 </Window>

--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
@@ -22,6 +24,23 @@ public partial class RadialMenuWindow : Window, IRadialMenu
         _audioService = audioService;
         _openAIService = openAIService;
         MicButton.Click += OnMicClicked;
+        CancelButton.Click += (_, _) => { CancelRequested?.Invoke(this, EventArgs.Empty); Hide(); };
+    }
+    
+    public event EventHandler? CancelRequested;
+
+    public void ShowLoading()
+    {
+        RootCanvas.Children.Clear();
+        var radius = 80d;
+        RootCanvas.Children.Add(Spinner);
+        RootCanvas.Children.Add(CancelButton);
+        Canvas.SetLeft(Spinner, radius - Spinner.Width / 2);
+        Canvas.SetTop(Spinner, radius - Spinner.Height / 2);
+        Canvas.SetLeft(CancelButton, radius - CancelButton.Width / 2);
+        Canvas.SetTop(CancelButton, radius + 20);
+        Spinner.Visibility = Visibility.Visible;
+        CancelButton.Visibility = Visibility.Visible;
     }
 
     public void Populate(string[] suggestions)
@@ -30,6 +49,8 @@ public partial class RadialMenuWindow : Window, IRadialMenu
         _recording = false;
         MicButton.Content = "🎤";
         MicButton.ClearValue(Control.BackgroundProperty);
+        Spinner.Visibility = Visibility.Collapsed;
+        CancelButton.Visibility = Visibility.Collapsed;
         var count = suggestions.Length;
         var radius = 80d;
         RootCanvas.Children.Add(MicButton);
@@ -115,5 +136,17 @@ public partial class RadialMenuWindow : Window, IRadialMenu
     {
         base.OnDeactivated(e);
         Hide();
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CancelRequested?.Invoke(this, EventArgs.Empty);
+            e.Handled = true;
+            Hide();
+            return;
+        }
+        base.OnKeyDown(e);
     }
 }

--- a/src/SpecialGuide.Core/Models/IRadialMenu.cs
+++ b/src/SpecialGuide.Core/Models/IRadialMenu.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace SpecialGuide.Core.Models;
 
 public interface IRadialMenu
 {
     void Populate(string[] suggestions);
     void Show(double x, double y);
+    void ShowLoading();
     void Hide();
+    event EventHandler? CancelRequested;
 }

--- a/src/SpecialGuide.Core/Services/AudioService.cs
+++ b/src/SpecialGuide.Core/Services/AudioService.cs
@@ -28,7 +28,9 @@ public class AudioService : IDisposable
     {
         if (!IsRecording)
         {
-            return Array.Empty<byte>();
+            var data = Stream?.ToArray() ?? Array.Empty<byte>();
+            Dispose();
+            return data;
         }
         if (_waveIn != null && _dataAvailableHandler != null)
         {
@@ -39,10 +41,10 @@ public class AudioService : IDisposable
         _waveIn?.StopRecording();
 
         Writer?.Flush();
-        var data = Stream?.ToArray() ?? Array.Empty<byte>();
+        var recorded = Stream?.ToArray() ?? Array.Empty<byte>();
         Dispose();
         IsRecording = false;
-        return data;
+        return recorded;
     }
 
     public void Dispose()

--- a/src/SpecialGuide.Core/Services/OverlayService.cs
+++ b/src/SpecialGuide.Core/Services/OverlayService.cs
@@ -1,4 +1,5 @@
 using SpecialGuide.Core.Models;
+using System;
 using System.Runtime.InteropServices;
 
 namespace SpecialGuide.Core.Services;
@@ -6,17 +7,30 @@ namespace SpecialGuide.Core.Services;
 public class OverlayService
 {
     private readonly IRadialMenu _menu;
+    private double _x;
+    private double _y;
+
+    public event EventHandler? CancelRequested;
 
     public OverlayService(IRadialMenu menu)
     {
         _menu = menu;
+        _menu.CancelRequested += (_, _) => CancelRequested?.Invoke(this, EventArgs.Empty);
     }
 
-    public void ShowAtCursor(string[] suggestions)
+    public void ShowLoadingAtCursor()
     {
         var pos = GetCursorPosition();
+        _x = pos.X;
+        _y = pos.Y;
+        _menu.ShowLoading();
+        _menu.Show(_x, _y);
+    }
+
+    public void ShowSuggestions(string[] suggestions)
+    {
         _menu.Populate(suggestions);
-        _menu.Show(pos.X, pos.Y);
+        _menu.Show(_x, _y);
     }
 
     public void Hide() => _menu.Hide();

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -1,5 +1,7 @@
-using SpecialGuide.Core.Services;
+using System;
+using System.Threading;
 using System.Threading.Tasks;
+using SpecialGuide.Core.Services;
 using Xunit;
 
 namespace SpecialGuide.Tests
@@ -14,7 +16,7 @@ public class SuggestionServiceTests
         var settings = new SettingsService(new Settings());
         var service = new SuggestionService(capture, openai, settings);
         var result = await service.GetSuggestionsAsync("app");
-        Assert.All(result, s => Assert.True(s.Length <= SuggestionService.DefaultMaxSuggestionLength));
+        Assert.All(result.Suggestions, s => Assert.True(s.Length <= SuggestionService.DefaultMaxSuggestionLength));
     }
 
     [Fact]
@@ -25,7 +27,32 @@ public class SuggestionServiceTests
         var settings = new SettingsService(new Settings { MaxSuggestionLength = 10 });
         var service = new SuggestionService(capture, openai, settings);
         var result = await service.GetSuggestionsAsync("app");
-        Assert.All(result, s => Assert.True(s.Length <= 10));
+        Assert.All(result.Suggestions, s => Assert.True(s.Length <= 10));
+    }
+
+    [Fact]
+    public async Task Returns_Canceled_On_Cancellation()
+    {
+        var capture = new FakeCaptureService();
+        var openai = new CancelingOpenAIService();
+        var settings = new SettingsService(new Settings());
+        var service = new SuggestionService(capture, openai, settings);
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var result = await service.GetSuggestionsAsync("app", cts.Token);
+        Assert.NotNull(result.Error);
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public async Task Propagates_Error_From_OpenAI()
+    {
+        var capture = new FakeCaptureService();
+        var openai = new ErrorOpenAIService();
+        var settings = new SettingsService(new Settings());
+        var service = new SuggestionService(capture, openai, settings);
+        var result = await service.GetSuggestionsAsync("app");
+        Assert.Equal("boom", result.Error);
     }
 
     private class FakeCaptureService : CaptureService
@@ -36,8 +63,25 @@ public class SuggestionServiceTests
     private class FakeOpenAIService : OpenAIService
     {
         public FakeOpenAIService() : base(new HttpClient(), new SettingsService(new Settings()), new LoggingService()) { }
-        public override Task<SuggestionResult> GenerateSuggestionsAsync(byte[] image, string appName)
+        public override Task<SuggestionResult> GenerateSuggestionsAsync(byte[] image, string appName, CancellationToken cancellationToken = default)
             => Task.FromResult(new SuggestionResult(new[] { new string('a', 100) }, null));
+    }
+
+    private class CancelingOpenAIService : OpenAIService
+    {
+        public CancelingOpenAIService() : base(new HttpClient(), new SettingsService(new Settings()), new LoggingService()) { }
+        public override Task<SuggestionResult> GenerateSuggestionsAsync(byte[] image, string appName, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new SuggestionResult(Array.Empty<string>(), null));
+        }
+    }
+
+    private class ErrorOpenAIService : OpenAIService
+    {
+        public ErrorOpenAIService() : base(new HttpClient(), new SettingsService(new Settings()), new LoggingService()) { }
+        public override Task<SuggestionResult> GenerateSuggestionsAsync(byte[] image, string appName, CancellationToken cancellationToken = default)
+            => Task.FromResult(new SuggestionResult(Array.Empty<string>(), "boom"));
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent multiple activations by tracking a busy state in `MainWindow`
- show a loading spinner with cancel support in `RadialMenuWindow`
- allow cancelling OpenAI suggestion requests and surface errors to the user
- fix AudioService `Stop` disposing when not recording
- cover cancellation and error propagation in `SuggestionService` tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c8928ad1c832881194895013a0da4