### PR TITLE
Add Hotkey setting and serialization test

### DIFF
--- a/src/SpecialGuide.Core/Models/Settings.cs
+++ b/src/SpecialGuide.Core/Models/Settings.cs
@@ -3,6 +3,7 @@ namespace SpecialGuide.Core.Models;
 public class Settings
 {
     public string ApiKey { get; set; } = string.Empty;
+    public string Hotkey { get; set; } = string.Empty;
     public bool AutoPaste { get; set; }
     public int MaxSuggestionLength { get; set; } = SpecialGuide.Core.Services.SuggestionService.DefaultMaxSuggestionLength;
 

--- a/src/SpecialGuide.Core/Services/SettingsService.cs
+++ b/src/SpecialGuide.Core/Services/SettingsService.cs
@@ -13,7 +13,7 @@ public class SettingsService : IDisposable
 
     public Settings Settings => _settings;
     public string ApiKey => _settings.ApiKey;
-    public string ActivationHotkey => _settings.ActivationHotkey;
+    public string Hotkey => _settings.Hotkey;
 
     public event Action<Settings>? SettingsChanged;
 

--- a/tests/SpecialGuide.Tests/SettingsServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SettingsServiceTests.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using SpecialGuide.Core.Models;
+
+namespace SpecialGuide.Tests;
+
+public class SettingsServiceTests
+{
+    [Fact]
+    public void SerializesAndDeserializesHotkey()
+    {
+        var settings = new Settings { Hotkey = "Ctrl+Shift+H" };
+        var json = JsonSerializer.Serialize(settings);
+        var loaded = JsonSerializer.Deserialize<Settings>(json);
+
+        Assert.Equal("Ctrl+Shift+H", loaded?.Hotkey);
+        Assert.Contains("\"Hotkey\":\"Ctrl+Shift+H\"", json);
+    }
+}
+

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -26,7 +26,8 @@
       <Compile Include="AudioServiceTests.cs" />
       <Compile Include="SuggestionServiceTests.cs" />
       <Compile Include="OpenAIServiceTests.cs" />
-      <Compile Include="HookServiceTests.cs" />
+        <Compile Include="HookServiceTests.cs" />
+        <Compile Include="SettingsServiceTests.cs" />
       <Compile Include="..\..\src\SpecialGuide.Core\Services\AudioService.cs" Link="Services/AudioService.cs" />
       <Compile Include="..\..\src\SpecialGuide.Core\Services\SuggestionService.cs" Link="Services/SuggestionService.cs" />
       <Compile Include="..\..\src\SpecialGuide.Core\Services\OpenAIService.cs" Link="Services/OpenAIService.cs" />


### PR DESCRIPTION
## Summary
- add `Hotkey` setting to configuration model
- expose new `Hotkey` via `SettingsService`
- cover JSON serialization/deserialization with a unit test

## Testing
- `dotnet test` *(fails: Invalid token ')' in HookServiceTests.cs)*

------
https://chatgpt.com/codex/tasks/task_e_689cf52433e88328993d1f5fdca8167d