### PR TITLE
Add hotkey setting and update serialization

### DIFF
--- a/src/SpecialGuide.Core/Models/Settings.cs
+++ b/src/SpecialGuide.Core/Models/Settings.cs
@@ -5,5 +5,6 @@ public class Settings
     public string ApiKey { get; set; } = string.Empty;
     public bool AutoPaste { get; set; }
     public int MaxSuggestionLength { get; set; } = SpecialGuide.Core.Services.SuggestionService.DefaultMaxSuggestionLength;
+    public string Hotkey { get; set; } = string.Empty;
 
 }

--- a/src/SpecialGuide.Core/Services/SettingsService.cs
+++ b/src/SpecialGuide.Core/Services/SettingsService.cs
@@ -13,7 +13,7 @@ public class SettingsService : IDisposable
 
     public Settings Settings => _settings;
     public string ApiKey => _settings.ApiKey;
-    public string ActivationHotkey => _settings.ActivationHotkey;
+    public string Hotkey => _settings.Hotkey;
 
     public event Action<Settings>? SettingsChanged;
 

--- a/tests/SpecialGuide.Tests/SettingsSerializationTests.cs
+++ b/tests/SpecialGuide.Tests/SettingsSerializationTests.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using SpecialGuide.Core.Models;
+
+namespace SpecialGuide.Tests;
+
+public class SettingsSerializationTests
+{
+    [Fact]
+    public void Hotkey_Serializes_And_Deserializes()
+    {
+        var settings = new Settings { Hotkey = "Ctrl+Alt+S" };
+
+        var json = JsonSerializer.Serialize(settings);
+        Assert.Contains("\"Hotkey\":\"Ctrl+Alt+S\"", json);
+
+        var loaded = JsonSerializer.Deserialize<Settings>(json);
+        Assert.Equal("Ctrl+Alt+S", loaded?.Hotkey);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `Hotkey` property to `Settings`
- expose hotkey through `SettingsService`
- test JSON serialization/deserialization of the hotkey

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found and compilation errors in HookServiceTests.cs)*


------
https://chatgpt.com/codex/tasks/task_e_689d3fd4084c8328bba8d0e2c8e761a4