### PR TITLE
Wire up hotkey and cancel events

### DIFF
--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ public partial class MainWindow : Window
         _windowService = windowService;
         _logger = logger;
 
+        _hookService.HotkeyPressed += async (sender, e) =>
         {
             try
             {
@@ -34,6 +35,9 @@ public partial class MainWindow : Window
                 _logger.LogError(ex, "Error handling hotkey");
             }
         };
+
+        _overlayService.CancelRequested += (_, _) => CancelActive();
+
         _hookService.Start();
         Closed += (_, _) => _hookService.Stop();
     }


### PR DESCRIPTION
## Summary
- Subscribe HookService's HotkeyPressed event to call OnHotkeyPressed asynchronously and log errors
- Invoke CancelActive when OverlayService raises CancelRequested

## Testing
- `dotnet test` *(fails: HookService.cs modifier not valid)*
- `dotnet build src/SpecialGuide.App/SpecialGuide.App.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d3fd4c6c0832884d110aba2d22192