### PR TITLE
Reload hooks after saving settings

### DIFF
--- a/src/SpecialGuide.App/SettingsWindow.xaml.cs
+++ b/src/SpecialGuide.App/SettingsWindow.xaml.cs
@@ -44,8 +44,7 @@ public partial class SettingsWindow : Window
             _settings.Settings.Hotkey = string.Empty;
         }
         _settings.Save();
-
-        }
+        _hookService.Reload();
         Close();
     }
 }


### PR DESCRIPTION
## Summary
- remove stray brace in `OnSave`
- reload hooks and close window on settings save so new hotkeys take effect immediately

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Invalid token '{' in HookServiceTests.cs and missing WindowsDesktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689d3fd5034483289405b880e8340550