### PR TITLE
Add unit tests for HookService hotkey handling

### DIFF
--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -1,19 +1,69 @@
-
+using System;
 using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
-using SpecialGuide.Core.Models;
 using Xunit;
 
 namespace SpecialGuide.Tests;
 
 public class HookServiceTests
 {
+    private int _keyboardHookCount;
+    private int _mouseHookCount;
 
+    private IntPtr RegisterHook(HookService.HookProc proc, int idHook)
+    {
+        // WH_KEYBOARD_LL = 13, WH_MOUSE_LL = 14
+        if (idHook == 13)
         {
-            if (hookId == new IntPtr(1)) KeyboardHookCount--;
-            if (hookId == new IntPtr(2)) MouseHookCount--;
-            return true;
+            _keyboardHookCount++;
+            return new IntPtr(1);
         }
+        if (idHook == 14)
+        {
+            _mouseHookCount++;
+            return new IntPtr(2);
+        }
+        return IntPtr.Zero;
+    }
 
+    private bool UnregisterHook(IntPtr hookId)
+    {
+        if (hookId == new IntPtr(1)) _keyboardHookCount--;
+        if (hookId == new IntPtr(2)) _mouseHookCount--;
+        return true;
+    }
+
+    [Fact]
+    public void TryParseHotkey_Parses_Valid_Combos()
+    {
+        var result = HookService.TryParseHotkey("Control+Shift+P", out var parsed);
+        Assert.True(result);
+        Assert.False(HookService.IsReservedHotkey(parsed));
+    }
+
+    [Fact]
+    public void IsReservedHotkey_Rejects_Duplicates_Or_Reserved()
+    {
+        HookService.TryParseHotkey("Control+Control+P", out var duplicate);
+        Assert.True(HookService.IsReservedHotkey(duplicate));
+
+        HookService.TryParseHotkey("Alt+F4", out var reserved);
+        Assert.True(HookService.IsReservedHotkey(reserved));
+    }
+
+    [Fact]
+    public void Start_Stop_UpdateHookIds()
+    {
+        var settings = new Settings();
+        var service = new HookService(new SettingsService(settings), RegisterHook, UnregisterHook);
+
+        service.Start();
+        Assert.Equal(1, _keyboardHookCount);
+        Assert.Equal(1, _mouseHookCount);
+
+        service.Stop();
+        Assert.Equal(0, _keyboardHookCount);
+        Assert.Equal(0, _mouseHookCount);
     }
 }
+


### PR DESCRIPTION
## Summary
- add tests for parsing hotkey strings and identifying reserved combos
- verify hook registration/unregistration updates hook IDs

## Testing
- `dotnet test --no-restore --verbosity normal` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_689d3fd57fb083288696652993c652d1