### PR TITLE
Add retry error handling for OpenAI service

### DIFF
--- a/src/SpecialGuide.Core/Services/SuggestionService.cs
+++ b/src/SpecialGuide.Core/Services/SuggestionService.cs
@@ -31,7 +31,7 @@ public class SuggestionService
         }
         catch (OperationCanceledException)
         {
-            return new SuggestionResult(Array.Empty<string>(), "Canceled");
+            return new SuggestionResult(Array.Empty<string>(), new OpenAIError(null, "Canceled"));
         }
     }
 }

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -41,6 +41,7 @@ public class SuggestionServiceTests
         cts.Cancel();
         var result = await service.GetSuggestionsAsync("app", cts.Token);
         Assert.NotNull(result.Error);
+        Assert.Equal("Canceled", result.Error!.Message);
         Assert.Empty(result.Suggestions);
     }
 
@@ -52,7 +53,7 @@ public class SuggestionServiceTests
         var settings = new SettingsService(new Settings());
         var service = new SuggestionService(capture, openai, settings);
         var result = await service.GetSuggestionsAsync("app");
-        Assert.Equal("boom", result.Error);
+        Assert.Equal("boom", result.Error?.Message);
     }
 
     private class FakeCaptureService : CaptureService
@@ -81,7 +82,7 @@ public class SuggestionServiceTests
     {
         public ErrorOpenAIService() : base(new HttpClient(), new SettingsService(new Settings()), new LoggingService()) { }
         public override Task<SuggestionResult> GenerateSuggestionsAsync(byte[] image, string appName, CancellationToken cancellationToken = default)
-            => Task.FromResult(new SuggestionResult(Array.Empty<string>(), "boom"));
+            => Task.FromResult(new SuggestionResult(Array.Empty<string>(), new OpenAIError(null, "boom")));
     }
 }
 


### PR DESCRIPTION
## Summary
- return structured `OpenAIError` details from OpenAIService
- backoff and retry on 429/5xx failures and log errors
- test handling of rate limits, retries, and malformed JSON

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; compile errors in HookService.cs)*

------
https://chatgpt.com/codex/tasks/task_e_689d3fd7c5608328a41179b6e81e1067