### PR TITLE
Add CaptureMode setting to configuration

### DIFF
--- a/src/SpecialGuide.Core/Models/Settings.cs
+++ b/src/SpecialGuide.Core/Models/Settings.cs
@@ -9,9 +9,9 @@ public enum CaptureMode
 public class Settings
 {
     public string ApiKey { get; set; } = string.Empty;
+    public CaptureMode CaptureMode { get; set; } = CaptureMode.FullScreen;
     public string Hotkey { get; set; } = string.Empty;
     public bool AutoPaste { get; set; }
     public int MaxSuggestionLength { get; set; } = SpecialGuide.Core.Services.SuggestionService.DefaultMaxSuggestionLength;
-    public string Hotkey { get; set; } = string.Empty;
 
 }


### PR DESCRIPTION
## Summary
- remove duplicated `Hotkey` property from settings
- add `CaptureMode` property with `FullScreen` default

## Testing
- `dotnet build` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_689fc78edbe48328a4acd4fa206f6b75