### PR TITLE
Propagate cancellation tokens and preserve stack traces

### DIFF
--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Threading;
 using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 
@@ -111,7 +112,7 @@ public partial class RadialMenuWindow : Window, IRadialMenu
             MicButton.ClearValue(Control.BackgroundProperty);
             try
             {
-                var text = await _openAIService.TranscribeAsync(data);
+                var text = await _openAIService.TranscribeAsync(data, CancellationToken.None);
                 if (!string.IsNullOrWhiteSpace(text))
                 {
                     _clipboardService.SetText(text);

--- a/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
+++ b/tests/SpecialGuide.Tests/OpenAIServiceTests.cs
@@ -19,7 +19,7 @@ namespace SpecialGuide.Tests
             var handler = new FakeHandler("{\"choices\":[{\"message\":{\"content\":\"[\\\"one\\\",\\\"two\\\"]\"}}]}");
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
-            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app", CancellationToken.None);
             Assert.Equal(new[] { "one", "two" }, result.Suggestions);
             Assert.Null(result.Error);
         }
@@ -30,7 +30,7 @@ namespace SpecialGuide.Tests
             var handler = new FakeHandler("{\"choices\":[{\"message\":{\"content\":\"not json\"}}]}");
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
-            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app", CancellationToken.None);
             Assert.NotNull(result.Error);
             Assert.Equal("Malformed response from OpenAI", result.Error!.Message);
             Assert.Empty(result.Suggestions);
@@ -50,7 +50,7 @@ namespace SpecialGuide.Tests
             var handler = new SequenceHandler(responses);
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
-            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app", CancellationToken.None);
             Assert.Equal(2, handler.Calls);
             Assert.Empty(result.Suggestions);
             Assert.Null(result.Error);
@@ -68,7 +68,7 @@ namespace SpecialGuide.Tests
             var handler = new SequenceHandler(responses);
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
-            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app", CancellationToken.None);
             Assert.Equal(3, handler.Calls);
             Assert.Empty(result.Suggestions);
             Assert.NotNull(result.Error);
@@ -87,7 +87,7 @@ namespace SpecialGuide.Tests
             var handler = new SequenceHandler(responses);
             var http = new HttpClient(handler);
             var service = new OpenAIService(http, new SettingsService(new Settings()), new LoggingService());
-            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app");
+            var result = await service.GenerateSuggestionsAsync(Array.Empty<byte>(), "app", CancellationToken.None);
             Assert.Equal(3, handler.Calls);
             Assert.Empty(result.Suggestions);
             Assert.NotNull(result.Error);

--- a/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
+++ b/tests/SpecialGuide.Tests/SuggestionServiceTests.cs
@@ -1,4 +1,4 @@
-
+using System.Threading;
 using System.Threading.Tasks;
 using SpecialGuide.Core.Services;
 using Xunit;
@@ -14,7 +14,7 @@ public class SuggestionServiceTests
         var openai = new FakeOpenAIService();
         var settings = new SettingsService(new Settings());
         var service = new SuggestionService(capture, openai, settings);
-        var result = await service.GetSuggestionsAsync("app");
+        var result = await service.GetSuggestionsAsync("app", CancellationToken.None);
         Assert.All(result.Suggestions, s => Assert.True(s.Length <= SuggestionService.DefaultMaxSuggestionLength));
     }
 
@@ -25,7 +25,7 @@ public class SuggestionServiceTests
         var openai = new FakeOpenAIService();
         var settings = new SettingsService(new Settings { MaxSuggestionLength = 10 });
         var service = new SuggestionService(capture, openai, settings);
-        var result = await service.GetSuggestionsAsync("app");
+        var result = await service.GetSuggestionsAsync("app", CancellationToken.None);
         Assert.All(result.Suggestions, s => Assert.True(s.Length <= 10));
     }
 
@@ -51,7 +51,7 @@ public class SuggestionServiceTests
         var openai = new ErrorOpenAIService();
         var settings = new SettingsService(new Settings());
         var service = new SuggestionService(capture, openai, settings);
-        var result = await service.GetSuggestionsAsync("app");
+        var result = await service.GetSuggestionsAsync("app", CancellationToken.None);
         Assert.Equal("boom", result.Error?.Message);
     }
 


### PR DESCRIPTION
## Summary
- allow cancellation in TranscribeAsync and ChatAsync
- rethrow HttpRequestExceptions in SendAsync without losing stack trace
- pass cancellation tokens through callers and tests

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc793117c83288c29554814979a07