### PR TITLE
Add HookService tests with injectable hook delegates

### DIFF
--- a/src/SpecialGuide.Core/Services/HookService.cs
+++ b/src/SpecialGuide.Core/Services/HookService.cs
@@ -13,28 +13,58 @@ namespace SpecialGuide.Core.Services;
 public class HookService : IDisposable
 {
     private readonly SettingsService _settings;
+    private readonly Func<int, HookProc, IntPtr, uint, IntPtr> _setHook;
+    private readonly Func<IntPtr, bool> _unhook;
 
-    private IntPtr _mouseHookId = IntPtr.Zero;
-    private IntPtr _keyboardHookId = IntPtr.Zero;
+    private IntPtr _mouseHookId;
+    private IntPtr _keyboardHookId;
     private HookProc? _mouseProc;
     private HookProc? _keyboardProc;
+    private Hotkey _hotkey;
+    private bool _overlayVisible;
 
+    public event EventHandler? HotkeyPressed;
 
     internal bool IsMouseHookActive => _mouseHookId != IntPtr.Zero;
     internal bool IsKeyboardHookActive => _keyboardHookId != IntPtr.Zero;
 
-
-    public HookService(SettingsService settings)
+    public HookService(
+        SettingsService settings,
+        Func<int, HookProc, IntPtr, uint, IntPtr>? setHook = null,
+        Func<IntPtr, bool>? unhook = null)
     {
         _settings = settings;
         _settings.SettingsChanged += _ => Reload();
+        _setHook = setHook ?? SetWindowsHookEx;
+        _unhook = unhook ?? UnhookWindowsHookEx;
     }
 
+    /// <summary>Start listening for hooks.</summary>
+    public void Start()
+    {
+        if (_mouseHookId == IntPtr.Zero)
         {
-            UnhookWindowsHookEx(_mouseHookId);
-            _mouseHookId = IntPtr.Zero;
+            _mouseProc = MouseHookCallback;
+            _mouseHookId = _setHook(WH_MOUSE_LL, _mouseProc, GetModuleHandle(Process.GetCurrentProcess().MainModule!.ModuleName), 0);
         }
+        Reload();
+    }
 
+    /// <summary>Stop listening for hooks.</summary>
+    public void Stop()
+    {
+        if (_mouseHookId != IntPtr.Zero)
+        {
+            _unhook(_mouseHookId);
+            _mouseHookId = IntPtr.Zero;
+            _mouseProc = null;
+        }
+        if (_keyboardHookId != IntPtr.Zero)
+        {
+            _unhook(_keyboardHookId);
+            _keyboardHookId = IntPtr.Zero;
+            _keyboardProc = null;
+        }
     }
 
     /// <summary>
@@ -42,7 +72,50 @@ public class HookService : IDisposable
     /// </summary>
     private void Reload()
     {
+        if (_keyboardHookId != IntPtr.Zero)
+        {
+            _unhook(_keyboardHookId);
+            _keyboardHookId = IntPtr.Zero;
+            _keyboardProc = null;
+        }
 
+        if (HotkeyFromString(_settings.Settings.Hotkey, out var hotkey))
+        {
+            _hotkey = hotkey;
+            _keyboardProc = KeyboardHookCallback;
+            _keyboardHookId = _setHook(WH_KEYBOARD_LL, _keyboardProc, GetModuleHandle(Process.GetCurrentProcess().MainModule!.ModuleName), 0);
+        }
+    }
+
+    internal static bool HotkeyFromString(string? text, out Hotkey result)
+    {
+        result = default;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        Keys mods = Keys.None;
+        Keys key = Keys.None;
+        foreach (var p in text.Split('+', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (Enum.TryParse<Keys>(p.Trim(), true, out var parsed))
+            {
+                switch (parsed)
+                {
+                    case Keys.Control:
+                    case Keys.ControlKey:
+                        mods |= Keys.Control;
+                        break;
+                    case Keys.Shift:
+                    case Keys.ShiftKey:
+                        mods |= Keys.Shift;
+                        break;
+                    case Keys.Menu:
+                    case Keys.Alt:
+                        mods |= Keys.Alt;
+                        break;
+                    default:
+                        key = parsed;
+                        break;
+                }
+            }
         }
         if (key == Keys.None) return false;
         result = new Hotkey(key, mods);
@@ -66,7 +139,6 @@ public class HookService : IDisposable
 
     public void Dispose() => Stop();
 
-
     private IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
         const int WM_MBUTTONDOWN = 0x0207;
@@ -85,9 +157,22 @@ public class HookService : IDisposable
     private IntPtr KeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
         const int WM_KEYDOWN = 0x0100;
+        if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
+        {
+            var kbd = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
+            var key = (Keys)kbd.vkCode;
+            var mods = Control.ModifierKeys;
+            if (key == _hotkey.Key && mods == _hotkey.Modifiers)
+            {
+                HotkeyPressed?.Invoke(this, EventArgs.Empty);
+                if (_overlayVisible)
+                    return new IntPtr(1);
+            }
+        }
+        return CallNextHookEx(_keyboardHookId, nCode, wParam, lParam);
+    }
 
-
-    private delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
+    internal delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct KBDLLHOOKSTRUCT
@@ -115,8 +200,4 @@ public class HookService : IDisposable
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     private static extern IntPtr GetModuleHandle(string lpModuleName);
-
-    [DllImport("user32.dll")]
-
 }
-

--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -1,5 +1,8 @@
 using System;
-
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 using Xunit;
 
@@ -7,19 +10,108 @@ namespace SpecialGuide.Tests;
 
 public class HookServiceTests
 {
+    private int _keyboardHookCount;
+    private int _mouseHookCount;
 
+    private IntPtr RegisterHook(int idHook, HookService.HookProc proc, IntPtr hMod, uint threadId)
+    {
+        if (idHook == 13) // keyboard
+        {
+            _keyboardHookCount++;
+            return new IntPtr(1);
+        }
+        if (idHook == 14) // mouse
+        {
+            _mouseHookCount++;
+            return new IntPtr(2);
         }
         return IntPtr.Zero;
     }
 
-    private bool UnregisterHook(IntPtr hookId)
+    private bool UnregisterHook(IntPtr id)
     {
-        if (hookId == new IntPtr(1)) _keyboardHookCount--;
-        if (hookId == new IntPtr(2)) _mouseHookCount--;
+        if (id == new IntPtr(1)) _keyboardHookCount--;
+        if (id == new IntPtr(2)) _mouseHookCount--;
         return true;
     }
 
+    private static void RaiseSettingsChanged(SettingsService svc)
+    {
+        var field = typeof(SettingsService).GetField("SettingsChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+        var del = (Action<Settings>?)field?.GetValue(svc);
+        del?.Invoke(svc.Settings);
+    }
 
+    private HookService CreateService(Settings settings)
+    {
+        var svc = new SettingsService(settings);
+        return new HookService(svc, RegisterHook, UnregisterHook);
+    }
+
+    [Fact]
+    public void Start_And_Stop_Register_Hooks()
+    {
+        var service = CreateService(new Settings());
+        service.Start();
+        Assert.Equal(1, _mouseHookCount);
+        service.Stop();
+        Assert.Equal(0, _mouseHookCount);
+    }
+
+    [Fact]
+    public void Reload_Responds_To_Setting_Changes()
+    {
+        var settings = new Settings();
+        var svc = new SettingsService(settings);
+        var service = new HookService(svc, RegisterHook, UnregisterHook);
+
+        service.Start();
+        Assert.Equal(0, _keyboardHookCount);
+
+        settings.Hotkey = "Alt+H";
+        RaiseSettingsChanged(svc);
+        Assert.Equal(1, _keyboardHookCount);
+
+        settings.Hotkey = string.Empty;
+        RaiseSettingsChanged(svc);
+        Assert.Equal(0, _keyboardHookCount);
+    }
+
+    [Fact]
+    public void HotkeyPressed_Fires_For_Mouse_Or_Hotkey()
+    {
+        var settings = new Settings { Hotkey = "Control+K" };
+        var svc = new SettingsService(settings);
+        var service = new HookService(svc, RegisterHook, UnregisterHook);
+        bool fired = false;
+        service.HotkeyPressed += (_, _) => fired = true;
+        service.Start();
+
+        // simulate middle click
+        var mouse = typeof(HookService).GetMethod("MouseHookCallback", BindingFlags.Instance | BindingFlags.NonPublic);
+        mouse!.Invoke(service, new object[] { 0, (IntPtr)0x0207, IntPtr.Zero });
+        Assert.True(fired);
+
+        fired = false;
+        // simulate hotkey press
+        var hotkeyField = typeof(HookService).GetField("_hotkey", BindingFlags.Instance | BindingFlags.NonPublic);
+        hotkeyField!.SetValue(service, new HookService.Hotkey(Keys.K, Keys.Control));
+        var kbdStruct = new KBDLLHOOKSTRUCT { vkCode = (uint)Keys.K };
+        var ptr = Marshal.AllocHGlobal(Marshal.SizeOf<KBDLLHOOKSTRUCT>());
+        Marshal.StructureToPtr(kbdStruct, ptr, false);
+        var keyboard = typeof(HookService).GetMethod("KeyboardHookCallback", BindingFlags.Instance | BindingFlags.NonPublic);
+        keyboard!.Invoke(service, new object[] { 0, (IntPtr)0x0100, ptr });
+        Marshal.FreeHGlobal(ptr);
+        Assert.True(fired);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KBDLLHOOKSTRUCT
+    {
+        public uint vkCode;
+        public uint scanCode;
+        public uint flags;
+        public uint time;
+        public IntPtr dwExtraInfo;
     }
 }
-

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -24,5 +24,14 @@
     <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
   </ItemGroup>
 
-  
+  <ItemGroup>
+    <Compile Include="GlobalUsings.cs" />
+    <Compile Include="HookServiceTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/SpecialGuide.Core/SpecialGuide.Core.csproj" />
+  </ItemGroup>
+
+
 </Project>


### PR DESCRIPTION
## Summary
- allow HookService to inject SetWindowsHookEx/UnhookWindowsHookEx delegates
- add comprehensive HookService tests for hook registration, reload, and hotkey events
- configure test project to include tests and reference core library

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc796a844832890b8d11357247746