### PR TITLE
Restore hook service hotkey registration and tests

### DIFF
--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -51,11 +51,24 @@ public class HookServiceTests
     [Fact]
     public void Start_And_Stop_Register_Hooks()
     {
-        var service = CreateService(new Settings());
+        var service = CreateService(new Settings { Hotkey = "Alt+H" });
         service.Start();
         Assert.Equal(1, _mouseHookCount);
+        Assert.Equal(1, _keyboardHookCount);
         service.Stop();
         Assert.Equal(0, _mouseHookCount);
+        Assert.Equal(0, _keyboardHookCount);
+    }
+
+    [Fact]
+    public void Constructor_Parses_Initial_Hotkey()
+    {
+        var service = CreateService(new Settings { Hotkey = "Control+K" });
+        var field = typeof(HookService).GetField("_hotkey", BindingFlags.Instance | BindingFlags.NonPublic);
+        var value = (HookService.Hotkey?)field!.GetValue(service);
+        Assert.NotNull(value);
+        Assert.Equal(Keys.K, value!.Value.Key);
+        Assert.Equal(Keys.Control, value.Value.Modifiers);
     }
 
     [Fact]
@@ -80,7 +93,7 @@ public class HookServiceTests
     [Fact]
     public void HotkeyPressed_Fires_For_Mouse_Or_Hotkey()
     {
-        var settings = new Settings { Hotkey = "Control+K" };
+        var settings = new Settings { Hotkey = "K" };
         var svc = new SettingsService(settings);
         var service = new HookService(svc, RegisterHook, UnregisterHook);
         bool fired = false;
@@ -94,8 +107,6 @@ public class HookServiceTests
 
         fired = false;
         // simulate hotkey press
-        var hotkeyField = typeof(HookService).GetField("_hotkey", BindingFlags.Instance | BindingFlags.NonPublic);
-        hotkeyField!.SetValue(service, new HookService.Hotkey(Keys.K, Keys.Control));
         var kbdStruct = new KBDLLHOOKSTRUCT { vkCode = (uint)Keys.K };
         var ptr = Marshal.AllocHGlobal(Marshal.SizeOf<KBDLLHOOKSTRUCT>());
         Marshal.StructureToPtr(kbdStruct, ptr, false);
@@ -103,6 +114,14 @@ public class HookServiceTests
         keyboard!.Invoke(service, new object[] { 0, (IntPtr)0x0100, ptr });
         Marshal.FreeHGlobal(ptr);
         Assert.True(fired);
+    }
+
+    [Fact]
+    public void TryParseHotkey_Parses_Modifiers_And_Key()
+    {
+        Assert.True(HookService.TryParseHotkey("Control+Shift+K", out var hotkey));
+        Assert.Equal(Keys.K, hotkey.Key);
+        Assert.Equal(Keys.Control | Keys.Shift, hotkey.Modifiers);
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
## Summary
- restore `HookService` constructor with optional hotkey and delegates
- implement Start/Stop, Reload, hotkey parsing, and callbacks
- add unit tests for constructor, lifecycle and hotkey parsing

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Could not find Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68a2deffca888328b1adb656eaedc9db