### PR TITLE
Handle capture failures in SuggestionService

### DIFF
--- a/src/SpecialGuide.Core/Services/SuggestionService.cs
+++ b/src/SpecialGuide.Core/Services/SuggestionService.cs
@@ -21,7 +21,16 @@ public class SuggestionService
 
     public async Task<SuggestionResult> GetSuggestionsAsync(string appName, CancellationToken cancellationToken = default)
     {
-        var image = _capture.CaptureScreen();
+        byte[] image;
+        try
+        {
+            image = _capture.CaptureScreen();
+        }
+        catch (Exception ex)
+        {
+            return new SuggestionResult(Array.Empty<string>(), new OpenAIError(null, ex.Message));
+        }
+
         try
         {
             var result = await _openAI.GenerateSuggestionsAsync(image, appName, cancellationToken);


### PR DESCRIPTION
## Summary
- Handle exceptions from `CaptureService` in `SuggestionService` and return an OpenAI error without invoking the API
- Add unit test to ensure capture errors are surfaced and OpenAI is not called

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2df01a35483288a9dbcfcd30c24d1