### PR TITLE
Handle AudioService state and add sequence tests

### DIFF
--- a/src/SpecialGuide.Core/SpecialGuide.Core.csproj
+++ b/src/SpecialGuide.Core/SpecialGuide.Core.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/tests/SpecialGuide.Tests/AudioServiceTests.cs
+++ b/tests/SpecialGuide.Tests/AudioServiceTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using NAudio.Wave;
 using SpecialGuide.Core.Services;
 using Xunit;
@@ -24,5 +26,44 @@ public class AudioServiceTests
 
         Assert.Null(service.Stream);
         Assert.Null(service.Writer);
+    }
+
+    private class TestAudioService : AudioService
+    {
+        private class StubWaveIn : IWaveIn
+        {
+            public WaveFormat WaveFormat { get; set; } = new WaveFormat(8000, 16, 1);
+            public event EventHandler<WaveInEventArgs>? DataAvailable;
+            public event EventHandler<StoppedEventArgs>? RecordingStopped;
+            public void StartRecording() { }
+            public void StopRecording() { }
+            public void Dispose() { }
+        }
+
+        public MemoryStream? TestStream => Stream;
+        public WaveFileWriter? TestWriter => Writer;
+        protected internal override IWaveIn CreateWaveInEvent() => new StubWaveIn();
+    }
+
+    [Fact]
+    public void StartStop_Can_Be_Called_Multiple_Times()
+    {
+        var service = new TestAudioService();
+
+        service.Start();
+        var data1 = service.Stop();
+        Assert.NotNull(data1);
+        Assert.Null(service.TestStream);
+        Assert.Null(service.TestWriter);
+
+        var empty = service.Stop();
+        Assert.Empty(empty);
+
+        service.Start();
+        service.Start(); // should be no-op
+        var data2 = service.Stop();
+        Assert.NotNull(data2);
+        Assert.Null(service.TestStream);
+        Assert.Null(service.TestWriter);
     }
 }

--- a/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
+++ b/tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <Compile Include="GlobalUsings.cs" />
     <Compile Include="HookServiceTests.cs" />
+    <Compile Include="AudioServiceTests.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- prevent starting audio recording twice by checking `IsRecording`
- avoid double disposal and return empty data when stopping without an active recording
- add tests for repeated Start/Stop sequences and ensure resources are released

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2df00d8988328932adba73c5891a3