### PR TITLE
Add hotkey capture settings and hook reload tests

### DIFF
--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -1,13 +1,19 @@
 <Window x:Class="SpecialGuide.App.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <StackPanel Margin="10">
         <TextBlock Text="API Key" />
         <TextBox Text="{Binding ApiKey}" Margin="0,0,0,10" />
+
         <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
+
         <TextBlock Text="Max Suggestion Length" />
         <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />
+
+        <TextBlock Text="Hotkey" />
+        <TextBox Text="{Binding Hotkey}" Margin="0,0,0,10" PreviewKeyDown="OnHotkeyPreviewKeyDown" IsReadOnly="True" />
+
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Save" Width="80" Margin="0,0,5,0" Click="OnSave" />
             <Button Content="Cancel" Width="80" Click="OnCancel" />

--- a/src/SpecialGuide.App/SettingsWindow.xaml.cs
+++ b/src/SpecialGuide.App/SettingsWindow.xaml.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Input;
+using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 
 namespace SpecialGuide.App;
@@ -6,19 +9,60 @@ namespace SpecialGuide.App;
 public partial class SettingsWindow : Window
 {
     private readonly SettingsService _settings;
+    private readonly Settings _model;
 
     public SettingsWindow(SettingsService settings)
     {
         InitializeComponent();
         _settings = settings;
-        DataContext = _settings.Settings;
+        var s = settings.Settings;
+        _model = new Settings
+        {
+            ApiKey = s.ApiKey,
+            AutoPaste = s.AutoPaste,
+            CaptureMode = s.CaptureMode,
+            Hotkey = s.Hotkey,
+            MaxSuggestionLength = s.MaxSuggestionLength,
+        };
+        DataContext = _model;
+    }
+
+    private void OnHotkeyPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        e.Handled = true;
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        if (key == Key.Escape)
+        {
+            _model.Hotkey = string.Empty;
+            return;
+        }
+
+        if (key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt
+            or Key.LeftShift or Key.RightShift or Key.LWin or Key.RWin)
+        {
+            return;
+        }
+
+        var parts = new List<string>();
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control)) parts.Add("Control");
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt)) parts.Add("Alt");
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift)) parts.Add("Shift");
+        parts.Add(key.ToString());
+        _model.Hotkey = string.Join("+", parts);
     }
 
     private void OnSave(object sender, RoutedEventArgs e)
     {
+        _settings.Settings.ApiKey = _model.ApiKey;
+        _settings.Settings.AutoPaste = _model.AutoPaste;
+        _settings.Settings.CaptureMode = _model.CaptureMode;
+        _settings.Settings.Hotkey = _model.Hotkey;
+        _settings.Settings.MaxSuggestionLength = _model.MaxSuggestionLength;
         _settings.Save();
 
         Close();
     }
+
+    private void OnCancel(object sender, RoutedEventArgs e) => Close();
 }
 

--- a/src/SpecialGuide.Core/Services/SettingsService.cs
+++ b/src/SpecialGuide.Core/Services/SettingsService.cs
@@ -86,12 +86,13 @@ public class SettingsService : IDisposable
         {
             var json = JsonSerializer.Serialize(_settings, CreateOptions());
             File.WriteAllText(_path, json);
-            SettingsChanged?.Invoke(_settings);
         }
         catch (Exception ex)
         {
             Warn($"Failed to save settings: {ex.Message}");
         }
+
+        SettingsChanged?.Invoke(_settings);
     }
 
     private static JsonSerializerOptions CreateOptions()

--- a/tests/SpecialGuide.Tests/HookServiceTests.cs
+++ b/tests/SpecialGuide.Tests/HookServiceTests.cs
@@ -91,6 +91,25 @@ public class HookServiceTests
     }
 
     [Fact]
+    public void Save_Reloads_Hooks_When_Hotkey_Changes()
+    {
+        var settings = new Settings();
+        var svc = new SettingsService(settings);
+        var service = new HookService(svc, RegisterHook, UnregisterHook);
+
+        service.Start();
+        Assert.Equal(0, _keyboardHookCount);
+
+        settings.Hotkey = "Alt+H";
+        svc.Save();
+        Assert.Equal(1, _keyboardHookCount);
+
+        settings.Hotkey = string.Empty;
+        svc.Save();
+        Assert.Equal(0, _keyboardHookCount);
+    }
+
+    [Fact]
     public void HotkeyPressed_Fires_For_Mouse_Or_Hotkey()
     {
         var settings = new Settings { Hotkey = "K" };


### PR DESCRIPTION
## Summary
- Add hotkey input in settings UI and capture key combinations
- Ensure settings save always notifies listeners for hotkey reloads
- Test that saving new hotkey causes hooks to reload

## Testing
- `dotnet test tests/SpecialGuide.Tests/SpecialGuide.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e89575c483288945369f3412b0f0