### PR TITLE
Persist API key from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Special Guide replaces the middle-mouse button with a radial AI assistant. When 
 
 ## Setup
 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/download).
-2. `cp .env/appsettings.sample .env/appsettings` and set `OPENAI_API_KEY`.
+2. `cp .env/appsettings.sample .env/appsettings` and set `OPENAI_API_KEY`, or export `OPENAI_API_KEY` in your environment; the app will pick it up on first run and save it to settings.
 3. Build and run:
    ```bash
    dotnet restore

--- a/src/SpecialGuide.Core/Services/SettingsService.cs
+++ b/src/SpecialGuide.Core/Services/SettingsService.cs
@@ -45,6 +45,16 @@ public class SettingsService : IDisposable
                 Save();
             }
 
+            if (string.IsNullOrWhiteSpace(_settings.ApiKey))
+            {
+                var envApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+                if (!string.IsNullOrWhiteSpace(envApiKey))
+                {
+                    _settings.ApiKey = envApiKey;
+                    Save();
+                }
+            }
+
             _watcher = new FileSystemWatcher(dir, Path.GetFileName(_path))
             {
                 NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.FileName


### PR DESCRIPTION
## Summary
- load OPENAI_API_KEY environment variable when settings ApiKey is blank and persist it
- document environment variable loading in setup instructions

## Testing
- `dotnet build` *(fails: The 'Project' start tag on line 1 position 2 does not match the end tag of 'ItemGroup'. Line 29, position 7.)*
- `dotnet test` *(fails: The 'Project' start tag on line 1 position 2 does not match the end tag of 'ItemGroup'. Line 29, position 7.)*

------
https://chatgpt.com/codex/tasks/task_e_68a35c2a9b48832883e260305f8afc62