### PR TITLE
Dispose cancellation token in MainWindow

### DIFF
--- a/src/SpecialGuide.App/MainWindow.xaml.cs
+++ b/src/SpecialGuide.App/MainWindow.xaml.cs
@@ -68,13 +68,15 @@ public partial class MainWindow : Window
         }
         finally
         {
+            _cts?.Dispose();
+            _cts = null;
             _busy = false;
         }
     }
 
     private void CancelActive()
     {
-        if (!_busy) return;
-        _cts?.Cancel();
+        if (!_busy || _cts == null) return;
+        _cts.Cancel();
     }
 }


### PR DESCRIPTION
## Summary
- Dispose and reset cancellation token after hotkey execution
- Guard cancel call when cancellation token source is missing

## Testing
- `dotnet test` *(fails: The 'Project' start tag on line 1 position 2 does not match the end tag of 'ItemGroup'. Line 29, position 7.)*

------
https://chatgpt.com/codex/tasks/task_e_68a35c2b2cd48328ad079c3f57483509