### PR TITLE
Add hotkey and capture mode settings

### DIFF
--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -1,12 +1,21 @@
 <Window x:Class="SpecialGuide.App.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StackPanel Margin="10">
         <TextBlock Text="API Key" />
         <TextBox Text="{Binding ApiKey}" Margin="0,0,0,10" />
 
         <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
 
+        <TextBlock Text="Hotkey" />
+        <TextBox Text="{Binding Hotkey}" Margin="0,0,0,10" />
+
+        <TextBlock Text="Capture Mode" />
+        <ComboBox SelectedValue="{Binding CaptureMode}" SelectedValuePath="Content" Margin="0,0,0,10">
+            <ComboBoxItem Content="FullScreen" />
+            <ComboBoxItem Content="ActiveWindow" />
+            <ComboBoxItem Content="CursorRegion" />
+        </ComboBox>
 
         <TextBlock Text="Max Suggestion Length" />
         <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />


### PR DESCRIPTION
## Summary
- close SettingsWindow root tag and add `xmlns:x`
- expose Hotkey and CaptureMode bindings in SettingsWindow

## Testing
- `dotnet test` *(fails: The 'Project' start tag on line 1 position 2 does not match the end tag of 'ItemGroup'. Line 29, position 7.)*

------
https://chatgpt.com/codex/tasks/task_e_68a35c2903fc832887af1c80857a13da