### PR TITLE
Ensure radial menu centers on cursor

### DIFF
--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
@@ -85,9 +85,14 @@ public partial class RadialMenuWindow : Window, IRadialMenu
 
     public void Show(double x, double y)
     {
-        Left = x - Width / 2;
-        Top = y - Height / 2;
+        // Display the window so that ActualWidth/ActualHeight are measured
         Show();
+        // Ensure layout is up to date before positioning
+        UpdateLayout();
+
+        // Center the menu on the cursor position
+        Left = x - ActualWidth / 2;
+        Top = y - ActualHeight / 2;
         _hookService.SetOverlayVisible(true);
         Activate();
     }


### PR DESCRIPTION
## Summary
- Fix `RadialMenuWindow.Show` to call `Show()` before positioning and center using `ActualWidth`/`ActualHeight`.

## Testing
- `dotnet test` *(fails: project file could not be loaded)*
- `dotnet build src/SpecialGuide.App/SpecialGuide.App.csproj` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36964ff8083288c6cdd87efb098ce