### PR TITLE
Add missing models namespace

### DIFF
--- a/src/SpecialGuide.App/App.xaml.cs
+++ b/src/SpecialGuide.App/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 
 namespace SpecialGuide.App;


### PR DESCRIPTION
## Summary
- add `SpecialGuide.Core.Models` namespace to App start-up

## Testing
- `dotnet build` *(fails: The SDK 'Microsoft.NET.Sdk.WindowsDesktop' specified could not be found.)*

------
https://chatgpt.com/codex/tasks/task_e_68a36964314c8328a357baf887870a8d