### PR TITLE
Improve settings validation and layout

### DIFF
--- a/src/SpecialGuide.App/SettingsViewModel.cs
+++ b/src/SpecialGuide.App/SettingsViewModel.cs
@@ -3,7 +3,7 @@ using SpecialGuide.Core.Models;
 
 namespace SpecialGuide.App;
 
-public class SettingsViewModel : INotifyPropertyChanged
+public class SettingsViewModel : INotifyPropertyChanged, IDataErrorInfo
 {
     private string _apiKey = string.Empty;
     private bool _autoPaste;
@@ -75,6 +75,18 @@ public class SettingsViewModel : INotifyPropertyChanged
             }
         }
     }
+
+    public string Error => string.Empty;
+
+    public string this[string columnName]
+        => columnName switch
+        {
+            nameof(ApiKey) when string.IsNullOrWhiteSpace(ApiKey)
+                => "API key is required.",
+            nameof(MaxSuggestionLength) when MaxSuggestionLength <= 0
+                => "Max suggestion length must be greater than zero.",
+            _ => string.Empty
+        };
 
     public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -1,29 +1,79 @@
 <Window x:Class="SpecialGuide.App.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Margin="10">
-        <TextBlock Text="API Key" />
-        <TextBox Text="{Binding ApiKey}" Margin="0,0,0,10" />
+    <Window.Resources>
+        <Style x:Key="ValidationTextBoxStyle" TargetType="TextBox">
+            <Setter Property="Validation.ErrorTemplate">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Border BorderBrush="Red" BorderThickness="1">
+                            <AdornedElementPlaceholder />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="Validation.HasError" Value="True">
+                    <Setter Property="ToolTip"
+                            Value="{Binding RelativeSource={RelativeSource Self}, Path=(Validation.Errors)[0].ErrorContent}" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
 
-        <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
-        <TextBlock Text="Hotkey" />
-        <TextBox Text="{Binding Hotkey}" Margin="0,0,0,10" />
+        <TextBlock Grid.Row="0" Text="API Key" Margin="0,0,5,5" />
+        <TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,0,10"
+                 Text="{Binding ApiKey, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                 Style="{StaticResource ValidationTextBoxStyle}" />
 
-        <TextBlock Text="Capture Mode" />
-        <ComboBox SelectedValue="{Binding CaptureMode}" SelectedValuePath="Content" Margin="0,0,0,10">
+        <CheckBox Grid.Row="1" Grid.ColumnSpan="2" Content="Auto Paste"
+                  IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
+
+        <TextBlock Grid.Row="2" Text="Hotkey" Margin="0,0,5,5" />
+        <TextBox Grid.Row="2" Grid.Column="1" Margin="0,0,0,10"
+                 Text="{Binding Hotkey}" />
+
+        <TextBlock Grid.Row="3" Text="Capture Mode" Margin="0,0,5,5" />
+        <ComboBox Grid.Row="3" Grid.Column="1" Margin="0,0,0,10"
+                  SelectedValue="{Binding CaptureMode}" SelectedValuePath="Content">
             <ComboBoxItem Content="FullScreen" />
             <ComboBoxItem Content="ActiveWindow" />
             <ComboBoxItem Content="CursorRegion" />
         </ComboBox>
 
-        <TextBlock Text="Max Suggestion Length" />
-        <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />
+        <TextBlock Grid.Row="4" Text="Max Suggestion Length" Margin="0,0,5,5" />
+        <TextBox Grid.Row="4" Grid.Column="1" Margin="0,0,0,10"
+                 Text="{Binding MaxSuggestionLength, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, ValidatesOnExceptions=True}"
+                 Style="{StaticResource ValidationTextBoxStyle}" />
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Save" Width="80" Margin="0,0,5,0" Click="OnSave" />
-            <Button Content="Cancel" Width="80" Click="OnCancel" />
+        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Click="OnSave" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Margin="0,0,5,0">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="💾" Margin="0,0,5,0" />
+                    <TextBlock Text="Save" />
+                </StackPanel>
+            </Button>
+            <Button Click="OnCancel" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="✖" Margin="0,0,5,0" />
+                    <TextBlock Text="Cancel" />
+                </StackPanel>
+            </Button>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Window>
 


### PR DESCRIPTION
## Summary
- Replace Settings window StackPanel with a two-column Grid
- Add validation for API key and suggestion length with tooltips
- Style Save/Cancel buttons with theme resources and icons

## Testing
- `dotnet test` *(fails: SpecialGuide.Tests.csproj cannot be loaded)*
- `dotnet build` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop workload)*

------
https://chatgpt.com/codex/tasks/task_e_68a44714eb64832889b641a1a20b725c