### PR TITLE
Refactor settings window with grid layout and validation

### DIFF
--- a/src/SpecialGuide.App/App.xaml
+++ b/src/SpecialGuide.App/App.xaml
@@ -3,5 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <FontFamily x:Key="DefaultFontFamily">Segoe UI</FontFamily>
+        <SolidColorBrush x:Key="DefaultForeground" Color="#333333"/>
     </Application.Resources>
 </Application>

--- a/src/SpecialGuide.App/SettingsWindow.xaml
+++ b/src/SpecialGuide.App/SettingsWindow.xaml
@@ -1,29 +1,59 @@
 <Window x:Class="SpecialGuide.App.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Margin="10">
-        <TextBlock Text="API Key" />
-        <TextBox Text="{Binding ApiKey}" Margin="0,0,0,10" />
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:val="clr-namespace:SpecialGuide.App.Validation"
+        Title="Settings" Height="Auto" Width="400">
+    <Grid Margin="10" FontFamily="{StaticResource DefaultFontFamily}" Foreground="{StaticResource DefaultForeground}">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
-        <CheckBox Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10" />
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="API Key" Margin="0,0,5,10"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,0,10">
+            <TextBox.Text>
+                <Binding Path="ApiKey" UpdateSourceTrigger="PropertyChanged">
+                    <Binding.ValidationRules>
+                        <val:NotEmptyValidationRule />
+                    </Binding.ValidationRules>
+                </Binding>
+            </TextBox.Text>
+        </TextBox>
 
-        <TextBlock Text="Hotkey" />
-        <TextBox Text="{Binding Hotkey}" Margin="0,0,0,10" />
+        <CheckBox Grid.Row="1" Grid.ColumnSpan="2" Content="Auto Paste" IsChecked="{Binding AutoPaste}" Margin="0,0,0,10"/>
 
-        <TextBlock Text="Capture Mode" />
-        <ComboBox SelectedValue="{Binding CaptureMode}" SelectedValuePath="Content" Margin="0,0,0,10">
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Hotkey" Margin="0,0,5,10"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Hotkey}" Margin="0,0,0,10"/>
+
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Capture Mode" Margin="0,0,5,10"/>
+        <ComboBox Grid.Row="3" Grid.Column="1" SelectedValue="{Binding CaptureMode}" SelectedValuePath="Content" Margin="0,0,0,10">
             <ComboBoxItem Content="FullScreen" />
             <ComboBoxItem Content="ActiveWindow" />
             <ComboBoxItem Content="CursorRegion" />
         </ComboBox>
 
-        <TextBlock Text="Max Suggestion Length" />
-        <TextBox Text="{Binding MaxSuggestionLength}" Margin="0,0,0,10" />
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Max Suggestion Length" Margin="0,0,5,10"/>
+        <TextBox Grid.Row="4" Grid.Column="1" Margin="0,0,0,10">
+            <TextBox.Text>
+                <Binding Path="MaxSuggestionLength" UpdateSourceTrigger="PropertyChanged">
+                    <Binding.ValidationRules>
+                        <val:NumericValidationRule />
+                    </Binding.ValidationRules>
+                </Binding>
+            </TextBox.Text>
+        </TextBox>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Save" Width="80" Margin="0,0,5,0" Click="OnSave" />
             <Button Content="Cancel" Width="80" Click="OnCancel" />
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Window>
-

--- a/src/SpecialGuide.App/Validation/NotEmptyValidationRule.cs
+++ b/src/SpecialGuide.App/Validation/NotEmptyValidationRule.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using System.Windows.Controls;
+
+namespace SpecialGuide.App.Validation;
+
+public class NotEmptyValidationRule : ValidationRule
+{
+    public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+    {
+        if (value is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            return ValidationResult.ValidResult;
+        }
+
+        return new ValidationResult(false, "Value cannot be empty");
+    }
+}

--- a/src/SpecialGuide.App/Validation/NumericValidationRule.cs
+++ b/src/SpecialGuide.App/Validation/NumericValidationRule.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using System.Windows.Controls;
+
+namespace SpecialGuide.App.Validation;
+
+public class NumericValidationRule : ValidationRule
+{
+    public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+    {
+        if (value == null)
+        {
+            return new ValidationResult(false, "Value is required");
+        }
+
+        return int.TryParse(value.ToString(), out _) 
+            ? ValidationResult.ValidResult 
+            : new ValidationResult(false, "Numeric value required");
+    }
+}


### PR DESCRIPTION
## Summary
- Use a grid-based layout for SettingsWindow so labels and fields align
- Add validation rules for ApiKey (required) and MaxSuggestionLength (numeric-only)
- Centralize default font and foreground resources in App.xaml

## Testing
- `dotnet test` *(fails: project file could not be loaded)*
- `dotnet build src/SpecialGuide.App/SpecialGuide.App.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae9933108328be6d77f58f63fc0f