### PR TITLE
Improve radial menu suggestion layout

### DIFF
--- a/src/SpecialGuide.App/Overlay/OverlayStyles.xaml
+++ b/src/SpecialGuide.App/Overlay/OverlayStyles.xaml
@@ -1,0 +1,28 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="SuggestionButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+        <Setter Property="MinWidth" Value="60" />
+        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="6"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml
@@ -3,6 +3,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         WindowStyle="None" AllowsTransparency="True" Background="Transparent"
         ShowInTaskbar="False" Topmost="True" SizeToContent="WidthAndHeight" Focusable="True">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="OverlayStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
     <Canvas x:Name="RootCanvas" Width="200" Height="200">
         <Button x:Name="MicButton" Content="🎤" Width="40" Height="40"/>
         <ProgressBar x:Name="Spinner" Width="60" Height="10" IsIndeterminate="True" Visibility="Collapsed"/>

--- a/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
+++ b/src/SpecialGuide.App/Overlay/RadialMenuWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Threading;
+using System.Collections.Generic;
 using SpecialGuide.Core.Models;
 using SpecialGuide.Core.Services;
 
@@ -39,6 +40,9 @@ public partial class RadialMenuWindow : Window, IRadialMenu
     {
         RootCanvas.Children.Clear();
         var radius = 80d;
+        var diameter = radius * 2;
+        RootCanvas.Width = diameter;
+        RootCanvas.Height = diameter;
         RootCanvas.Children.Add(Spinner);
         RootCanvas.Children.Add(CancelButton);
         Canvas.SetLeft(Spinner, radius - Spinner.Width / 2);
@@ -60,25 +64,45 @@ public partial class RadialMenuWindow : Window, IRadialMenu
         CancelButton.Visibility = Visibility.Collapsed;
         var count = suggestions.Length;
         var radius = 80d;
+
+        var buttons = new List<Button>();
+        double maxWidth = 0, maxHeight = 0;
+        foreach (var text in suggestions)
+        {
+            var button = new Button
+            {
+                Content = text,
+                Tag = text,
+                Style = (Style)FindResource("SuggestionButtonStyle")
+            };
+            button.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            maxWidth = Math.Max(maxWidth, button.DesiredSize.Width);
+            maxHeight = Math.Max(maxHeight, button.DesiredSize.Height);
+            buttons.Add(button);
+        }
+
+        var centerX = radius + maxWidth / 2;
+        var centerY = radius + maxHeight / 2;
+
+        RootCanvas.Width = 2 * radius + maxWidth;
+        RootCanvas.Height = 2 * radius + maxHeight;
+
         RootCanvas.Children.Add(MicButton);
         RootCanvas.Children.Add(HistoryButton);
-        Canvas.SetLeft(MicButton, radius - MicButton.Width / 2);
-        Canvas.SetTop(MicButton, radius - MicButton.Height / 2);
-        Canvas.SetLeft(HistoryButton, radius - HistoryButton.Width / 2);
-        Canvas.SetTop(HistoryButton, radius + 20);
+        Canvas.SetLeft(MicButton, centerX - MicButton.Width / 2);
+        Canvas.SetTop(MicButton, centerY - MicButton.Height / 2);
+        Canvas.SetLeft(HistoryButton, centerX - HistoryButton.Width / 2);
+        Canvas.SetTop(HistoryButton, centerY + 20);
         HistoryButton.Visibility = Visibility.Visible;
+
         for (int i = 0; i < count; i++)
         {
             var angle = 2 * Math.PI * i / count;
-            var button = new Button
-            {
-                Content = suggestions[i],
-                Width = 80,
-                Height = 30,
-                Tag = suggestions[i]
-            };
-            Canvas.SetLeft(button, radius + radius * Math.Cos(angle) - 40);
-            Canvas.SetTop(button, radius + radius * Math.Sin(angle) - 15);
+            var button = buttons[i];
+            var w = button.DesiredSize.Width;
+            var h = button.DesiredSize.Height;
+            Canvas.SetLeft(button, centerX + radius * Math.Cos(angle) - w / 2);
+            Canvas.SetTop(button, centerY + radius * Math.Sin(angle) - h / 2);
             button.Click += (_, _) => OnSuggestionSelected((string)button.Tag);
             RootCanvas.Children.Add(button);
         }


### PR DESCRIPTION
## Summary
- Style suggestion buttons with rounded corners and theme-aware colors
- Size buttons based on text using `Measure`/`DesiredSize`
- Center radial menu around cursor regardless of suggestion length

## Testing
- `dotnet test` *(fails: The 'Project' start tag on line 1 position 2 does not match the end tag of 'ItemGroup')*
- `dotnet build` *(fails: The SDK 'Microsoft.NET.Sdk.WindowsDesktop' specified could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae9888bc8328a57587266add4314